### PR TITLE
Doc: 어드민 영역 스웨거 문서 작업

### DIFF
--- a/application-admin/src/main/java/com/nowait/applicationadmin/menu/controller/MenuController.java
+++ b/application-admin/src/main/java/com/nowait/applicationadmin/menu/controller/MenuController.java
@@ -17,17 +17,25 @@ import com.nowait.applicationadmin.menu.dto.MenuUpdateRequest;
 import com.nowait.applicationadmin.menu.service.MenuService;
 import com.nowait.common.api.ApiUtils;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Tag(name = "Menu API", description = "메뉴 API")
 @RestController
 @RequestMapping("/admin/menus")
 @RequiredArgsConstructor
+@Slf4j
 public class MenuController {
 
 	private final MenuService menuService;
 
 	@PostMapping("/create")
+	@Operation(summary = "메뉴 생성", description = "새로운 메뉴를 생성합니다.")
+	@ApiResponse(responseCode = "201", description = "메뉴 생성")
 	public ResponseEntity<?> createMenu(@Valid @RequestBody MenuCreateRequest request) {
 		MenuCreateResponse response = menuService.createMenu(request);
 
@@ -41,6 +49,8 @@ public class MenuController {
 	}
 
 	@GetMapping("/all-menus/stores/{storeId}")
+	@Operation(summary = "가게의 모든 메뉴 조회", description = "특정 가게의 모든 메뉴를 조회")
+	@ApiResponse(responseCode = "200", description = "가게의 모든 메뉴 조회")
 	public ResponseEntity<?> getMenusByStoreId(@PathVariable Long storeId) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
@@ -52,6 +62,8 @@ public class MenuController {
 	}
 
 	@GetMapping("/{storeId}/{menuId}")
+	@Operation(summary = "메뉴 상세 조회", description = "특정 메뉴의 상세 정보를 조회")
+	@ApiResponse(responseCode = "200", description = "메뉴 상세 조회")
 	public ResponseEntity<?> getMenuById(
 		@PathVariable Long storeId,
 		@PathVariable Long menuId
@@ -67,6 +79,8 @@ public class MenuController {
 
 
 	@PatchMapping("/update/{menuId}")
+	@Operation(summary = "메뉴 수정", description = "특정 메뉴의 정보를 수정합니다.")
+	@ApiResponse(responseCode = "200", description = "메뉴 수정")
 	public ResponseEntity<?> updateMenu(
 		@PathVariable Long menuId,
 		@Valid @RequestBody MenuUpdateRequest request
@@ -81,6 +95,8 @@ public class MenuController {
 	}
 
 	@DeleteMapping("/delete/{menuId}")
+	@Operation(summary = "메뉴 삭제", description = "특정 메뉴를 삭제합니다.")
+	@ApiResponse(responseCode = "200", description = "메뉴 삭제")
 	public ResponseEntity<?> deleteMenu(@PathVariable Long menuId) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
@@ -92,6 +108,8 @@ public class MenuController {
 	}
 
 	@PatchMapping("/toggle-soldout/{menuId}")
+	@Operation(summary = "메뉴 판매 중지/재개", description = "특정 메뉴의 판매 상태를 판매 중지 또는 재개로 토글합니다.")
+	@ApiResponse(responseCode = "200", description = "메뉴 판매 상태 토글")
 	public ResponseEntity<?> toggleSoldOut(@PathVariable Long menuId) {
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/application-admin/src/main/java/com/nowait/applicationadmin/menu/controller/MenuImageController.java
+++ b/application-admin/src/main/java/com/nowait/applicationadmin/menu/controller/MenuImageController.java
@@ -14,16 +14,27 @@ import com.nowait.applicationadmin.menu.dto.MenuImageUploadResponse;
 import com.nowait.applicationadmin.menu.service.MenuImageService;
 import com.nowait.common.api.ApiUtils;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Tag(name = "Menu Image API", description = "메뉴 이미지 API")
 @RestController
 @RequestMapping("/admin/menus")
 @RequiredArgsConstructor
+@Slf4j
 public class MenuImageController {
 
 	private final MenuImageService menuImageService;
 
 	@PostMapping("/images/{menuId}")
+	@Operation(
+		summary = "메뉴 이미지 업로드",
+		description = "특정 메뉴에 대한 이미지를 업로드합니다. 파일 크기는 최대 10MB로 제한됩니다."
+	)
+	@ApiResponse(responseCode = "201", description = "메뉴 이미지 업로드 성공")
 	public ResponseEntity<?> uploadMenuImage(
 		@PathVariable Long menuId,
 		@RequestParam("file") MultipartFile file
@@ -40,11 +51,16 @@ public class MenuImageController {
 	}
 
 	@DeleteMapping("/images/{menuImageId}")
+	@Operation(
+		summary = "메뉴 이미지 삭제",
+		description = "특정 메뉴 이미지 ID에 해당하는 이미지를 삭제합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "메뉴 이미지 삭제 성공")
 	public ResponseEntity<?> deleteMenuImage(@PathVariable Long id) {
 		menuImageService.delete(id);
 		return ResponseEntity
 			.status(
-				HttpStatus.NO_CONTENT
+				HttpStatus.OK
 			)
 			.body(
 				ApiUtils

--- a/application-admin/src/main/java/com/nowait/applicationadmin/store/controller/StoreController.java
+++ b/application-admin/src/main/java/com/nowait/applicationadmin/store/controller/StoreController.java
@@ -17,17 +17,26 @@ import com.nowait.applicationadmin.store.dto.StoreUpdateRequest;
 import com.nowait.applicationadmin.store.service.StoreService;
 import com.nowait.common.api.ApiUtils;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Tag(name = "Store API", description = "주점(Store) API")
 @RestController
 @RequestMapping("admin/stores")
 @RequiredArgsConstructor
+@Slf4j
 public class StoreController {
 
 	private final StoreService storeService;
 
+	// 주점 생성
 	@PostMapping("/create")
+	@Operation(summary = "주점 생성", description = "새로운 주점을 생성합니다.")
+	@ApiResponse(responseCode = "201", description = "주점 생성 성공")
 	public ResponseEntity<?> createStore(@Valid @RequestBody StoreCreateRequest request) {
 		StoreCreateResponse response = storeService.createStore(request);
 
@@ -41,6 +50,8 @@ public class StoreController {
 	}
 
 	@GetMapping("/{storeId}")
+	@Operation(summary = "주점 조회", description = "주점 ID로 주점을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "주점 조회 성공")
 	public ResponseEntity<?> getStoreById(@PathVariable Long storeId) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
@@ -52,6 +63,8 @@ public class StoreController {
 	}
 
 	@PatchMapping("/{storeId}")
+	@Operation(summary = "주점 정보 수정", description = "주점 ID로 주점 정보를 수정합니다.")
+	@ApiResponse(responseCode = "200", description = "주점 정보 수정 성공")
 	public ResponseEntity<?> updateStore(
 		@PathVariable Long storeId,
 		@Valid @RequestBody StoreUpdateRequest request
@@ -66,6 +79,8 @@ public class StoreController {
 	}
 
 	@DeleteMapping("/{storeId}")
+	@Operation(summary = "주점 삭제", description = "주점 ID로 주점을 삭제합니다.")
+	@ApiResponse(responseCode = "200", description = "주점 삭제 성공")
 	public ResponseEntity<?> deleteStore(@PathVariable Long storeId) {
 		return ResponseEntity
 			.ok()
@@ -77,6 +92,8 @@ public class StoreController {
 	}
 
 	@PatchMapping("/toggle-active/{storeId}")
+	@Operation(summary = "주점 활성화/비활성화 토글", description = "주점 ID로 주점의 활성화 상태를 토글합니다.")
+	@ApiResponse(responseCode = "200", description = "주점 활성화/비활성화 토글 성공")
 	public ResponseEntity<?> toggleActive(@PathVariable Long storeId) {
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/application-admin/src/main/java/com/nowait/applicationadmin/store/controller/StoreImageController.java
+++ b/application-admin/src/main/java/com/nowait/applicationadmin/store/controller/StoreImageController.java
@@ -16,8 +16,12 @@ import com.nowait.applicationadmin.store.dto.StoreImageUploadResponse;
 import com.nowait.applicationadmin.store.service.StoreImageService;
 import com.nowait.common.api.ApiUtils;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Store Image API", description = "주점 이미지 API")
 @RestController
 @RequestMapping("/admin/stores")
 @RequiredArgsConstructor
@@ -26,6 +30,11 @@ public class StoreImageController {
 	private final StoreImageService storeImageService;
 
 	@PostMapping("/store-images/{storeId}")
+	@Operation(
+		summary = "주점 이미지 업로드",
+		description = "주점에 이미지를 업로드합니다. 최대 10개의 이미지 파일을 업로드할 수 있습니다."
+	)
+	@ApiResponse(responseCode = "201", description = "주점 이미지 업로드 성공")
 	public ResponseEntity<?> uploadStoreImage(
 		@PathVariable Long storeId,
 		@RequestParam("files") List<MultipartFile> files
@@ -56,10 +65,15 @@ public class StoreImageController {
 	}
 
 	@DeleteMapping("/store-images/{storeImageId}")
+	@Operation(
+		summary = "주점 이미지 삭제",
+		description = "주점 이미지를 삭제합니다. 이미지 ID를 사용하여 특정 이미지를 삭제할 수 있습니다."
+	)
+	@ApiResponse(responseCode = "200", description = "주점 이미지 삭제 성공")
 	public ResponseEntity<?> deleteStoreImage(@PathVariable Long imageId) {
 		storeImageService.delete(imageId);
 		return ResponseEntity
-			.status(HttpStatus.NO_CONTENT)
+			.status(HttpStatus.OK)
 			.body(
 				ApiUtils
 					.success(

--- a/application-admin/src/main/java/com/nowait/applicationadmin/token/controller/TokenController.java
+++ b/application-admin/src/main/java/com/nowait/applicationadmin/token/controller/TokenController.java
@@ -13,9 +13,13 @@ import com.nowait.applicationadmin.token.dto.RefreshTokenRequest;
 import com.nowait.applicationadmin.token.service.TokenService;
 import com.nowait.adminsecurity.auth.jwt.JwtUtil;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@Tag(name = "Token API", description = "토큰 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/refresh-token")
@@ -27,7 +31,10 @@ public class TokenController {
     private long accessTokenExpiration;
     @Value("${jwt.refresh-token-expiration-ms}")
     private long refreshTokenExpiration;
+
     @PostMapping
+    @Operation(summary = "리프레시 토큰", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.")
+    @ApiResponse(responseCode = "200", description = "새로운 액세스 토큰과 리프레시 토큰 발급 성공")
     public ResponseEntity<?> refreshToken(@RequestBody RefreshTokenRequest request){
         String refreshToken = request.getRefreshToken();
 

--- a/domain-menu/src/main/java/com/nowait/menu/entity/Menu.java
+++ b/domain-menu/src/main/java/com/nowait/menu/entity/Menu.java
@@ -3,6 +3,7 @@ package com.nowait.menu.entity;
 import java.time.LocalDateTime;
 import com.nowait.base.BaseTimeEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -25,11 +26,23 @@ public class Menu extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long Id;
+
+	@Column(nullable = false)
 	private Long storeId;
+
+	@Column(nullable = false)
 	private String name;
+
+	@Column(nullable = true)
 	private String description;
+
+	@Column(nullable = true)
 	private Integer price;
+
+	@Column(nullable = false)
 	private	Boolean isSoldOut;
+
+	@Column(nullable = false)
 	private Boolean deleted;
 
 

--- a/domain-menu/src/main/java/com/nowait/menu/entity/MenuImage.java
+++ b/domain-menu/src/main/java/com/nowait/menu/entity/MenuImage.java
@@ -29,6 +29,7 @@ public class MenuImage extends BaseTimeEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "menu_id")
+	@Column(nullable = false)
 	private Menu menu;
 
 	@Column(nullable = false, length = 500)

--- a/domain-store/src/main/java/com/nowait/store/entity/Store.java
+++ b/domain-store/src/main/java/com/nowait/store/entity/Store.java
@@ -29,21 +29,23 @@ public class Store extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long storeId;
 
+	@Column(name = "department_id", nullable = false)
 	private Long departmentId;
 
+	@Column(nullable = false, length = 200)
 	private String name;
 
+	@Column(nullable = true, length = 200)
 	private String location;
 
+	@Column(nullable = true, length = 200)
 	private String description;
 
-	@Builder.Default
 	@Column(name = "is_active", nullable = false)
-	private Boolean isActive = false;
+	private Boolean isActive;
 
-	@Builder.Default
-	@Column
-	private Boolean deleted = false;
+	@Column(nullable = false)
+	private Boolean deleted;
 
 	public Store(LocalDateTime createdAt, Long storeId, Long departmentId, String name, String location,
 		String description, Boolean isActive, Boolean deleted) {

--- a/domain-store/src/main/java/com/nowait/store/entity/StoreImage.java
+++ b/domain-store/src/main/java/com/nowait/store/entity/StoreImage.java
@@ -29,6 +29,7 @@ public class StoreImage extends BaseTimeEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id")
+	@Column(nullable = false)
 	private Store store;
 
 	@Column(nullable = false, length = 500)


### PR DESCRIPTION
## 작업 요약
어드민 영역 스웨거 문서 작업
## Issue Link
#29 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 메뉴, 메뉴 이미지, 주점, 주점 이미지, 토큰 관련 API에 대한 Swagger(OpenAPI) 문서화가 추가되어 API 명세 확인이 용이해졌습니다.
  * 각 컨트롤러에 로그 기능이 추가되었습니다.

* **Style**
  * 메뉴, 메뉴 이미지, 주점, 주점 이미지 엔티티의 컬럼에 명시적인 JPA 제약 조건(Nullable 등)이 추가되어 데이터베이스 스키마가 명확해졌습니다.
  * 일부 엔티티 필드의 기본값 설정이 제거되고 명시적 제약 조건으로 대체되었습니다.

* **Bug Fixes**
  * 이미지 삭제 API의 응답 코드가 204에서 200으로 변경되어 성공 시 메시지 본문이 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->