### PR TITLE
feat(Menu): 관리자 접근 제한

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/exception/GlobalExceptionHandler.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/exception/GlobalExceptionHandler.java
@@ -21,6 +21,10 @@ import com.nowait.applicationadmin.security.exception.ResourceNotFoundException;
 import com.nowait.applicationadmin.security.exception.UnauthorizedException;
 import com.nowait.common.exception.ErrorMessage;
 import com.nowait.common.exception.ErrorResponse;
+import com.nowait.domaincorerdb.menu.exception.MenuCreationUnauthorizedException;
+import com.nowait.domaincorerdb.menu.exception.MenuDeleteUnauthorizedException;
+import com.nowait.domaincorerdb.menu.exception.MenuUpdateUnauthorizedException;
+import com.nowait.domaincorerdb.menu.exception.MenuViewUnauthorizedException;
 import com.nowait.domaincorerdb.order.exception.DuplicateOrderException;
 import com.nowait.domaincorerdb.order.exception.OrderItemsEmptyException;
 import com.nowait.domaincorerdb.order.exception.OrderParameterEmptyException;
@@ -126,6 +130,34 @@ public class GlobalExceptionHandler {
 	public ErrorResponse reservationNotFoundException(ReservationNotFoundException e) {
 		log.error("reservationNotFoundException", e);
 		return new ErrorResponse(e.getMessage(), NOTFOUND_RESERVATION.getCode());
+	}
+
+	@ResponseStatus(value = FORBIDDEN)
+	@ExceptionHandler(MenuCreationUnauthorizedException.class)
+	public ErrorResponse menuCreationUnauthorizedException(MenuCreationUnauthorizedException e) {
+		log.error("menuCreationUnauthorizedException", e);
+		return new ErrorResponse(e.getMessage(), MENU_CREATION_UNAUTHORIZED.getCode());
+	}
+
+	@ResponseStatus(value = FORBIDDEN)
+	@ExceptionHandler(MenuViewUnauthorizedException.class)
+	public ErrorResponse menuViewUnauthorizedException(MenuViewUnauthorizedException e) {
+		log.error("menuViewUnauthorizedException", e);
+		return new ErrorResponse(e.getMessage(), MENU_VIEW_UNAUTHORIZED.getCode());
+	}
+
+	@ResponseStatus(value = FORBIDDEN)
+	@ExceptionHandler(MenuUpdateUnauthorizedException.class)
+	public ErrorResponse menuUpdateUnauthorizedException(MenuUpdateUnauthorizedException e) {
+		log.error("menuUpdateUnauthorizedException", e);
+		return new ErrorResponse(e.getMessage(), MENU_UPDATE_UNAUTHORIZED.getCode());
+	}
+
+	@ResponseStatus(value = FORBIDDEN)
+	@ExceptionHandler(MenuDeleteUnauthorizedException.class)
+	public ErrorResponse menuDeleteUnauthorizedException(MenuDeleteUnauthorizedException e) {
+		log.error("menuDeleteUnauthorizedException", e);
+		return new ErrorResponse(e.getMessage(), MENU_DELETE_UNAUTHORIZED.getCode());
 	}
 
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/controller/MenuController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/controller/MenuController.java
@@ -2,6 +2,7 @@ package com.nowait.applicationadmin.menu.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,6 +17,7 @@ import com.nowait.applicationadmin.menu.dto.MenuCreateResponse;
 import com.nowait.applicationadmin.menu.dto.MenuUpdateRequest;
 import com.nowait.applicationadmin.menu.service.MenuService;
 import com.nowait.common.api.ApiUtils;
+import com.nowait.domaincorerdb.user.entity.MemberDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -36,8 +38,9 @@ public class MenuController {
 	@PostMapping("/create")
 	@Operation(summary = "메뉴 생성", description = "새로운 메뉴를 생성합니다.")
 	@ApiResponse(responseCode = "201", description = "메뉴 생성")
-	public ResponseEntity<?> createMenu(@Valid @RequestBody MenuCreateRequest request) {
-		MenuCreateResponse response = menuService.createMenu(request);
+	public ResponseEntity<?> createMenu(@Valid @RequestBody MenuCreateRequest request,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		MenuCreateResponse response = menuService.createMenu(request,memberDetails);
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
@@ -51,12 +54,13 @@ public class MenuController {
 	@GetMapping("/all-menus/stores/{storeId}")
 	@Operation(summary = "가게의 모든 메뉴 조회", description = "특정 가게의 모든 메뉴를 조회")
 	@ApiResponse(responseCode = "200", description = "가게의 모든 메뉴 조회")
-	public ResponseEntity<?> getMenusByStoreId(@PathVariable Long storeId) {
+	public ResponseEntity<?> getMenusByStoreId(@PathVariable Long storeId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(
 				ApiUtils.success(
-					menuService.getAllMenusByStoreId(storeId)
+					menuService.getAllMenusByStoreId(storeId,memberDetails)
 				)
 			);
 	}
@@ -66,13 +70,14 @@ public class MenuController {
 	@ApiResponse(responseCode = "200", description = "메뉴 상세 조회")
 	public ResponseEntity<?> getMenuById(
 		@PathVariable Long storeId,
-		@PathVariable Long menuId
+		@PathVariable Long menuId,
+		@AuthenticationPrincipal MemberDetails memberDetails
 	) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(
 				ApiUtils.success(
-					menuService.getMenuById(storeId, menuId)
+					menuService.getMenuById(storeId, menuId,memberDetails)
 				)
 			);
 	}
@@ -83,13 +88,14 @@ public class MenuController {
 	@ApiResponse(responseCode = "200", description = "메뉴 수정")
 	public ResponseEntity<?> updateMenu(
 		@PathVariable Long menuId,
-		@Valid @RequestBody MenuUpdateRequest request
+		@Valid @RequestBody MenuUpdateRequest request,
+		@AuthenticationPrincipal MemberDetails memberDetails
 	) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(
 				ApiUtils.success(
-					menuService.updateMenu(menuId, request)
+					menuService.updateMenu(menuId, request,memberDetails)
 				)
 			);
 	}
@@ -97,12 +103,12 @@ public class MenuController {
 	@DeleteMapping("/delete/{menuId}")
 	@Operation(summary = "메뉴 삭제", description = "특정 메뉴를 삭제합니다.")
 	@ApiResponse(responseCode = "200", description = "메뉴 삭제")
-	public ResponseEntity<?> deleteMenu(@PathVariable Long menuId) {
+	public ResponseEntity<?> deleteMenu(@PathVariable Long menuId,@AuthenticationPrincipal MemberDetails memberDetails) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(
 				ApiUtils.success(
-					menuService.deleteMenu(menuId)
+					menuService.deleteMenu(menuId,memberDetails)
 				)
 			);
 	}

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuService.java
@@ -11,12 +11,21 @@ import com.nowait.applicationadmin.menu.dto.MenuImageUploadResponse;
 import com.nowait.applicationadmin.menu.dto.MenuReadDto;
 import com.nowait.applicationadmin.menu.dto.MenuReadResponse;
 import com.nowait.applicationadmin.menu.dto.MenuUpdateRequest;
+import com.nowait.common.enums.Role;
 import com.nowait.domaincorerdb.menu.entity.Menu;
 import com.nowait.domaincorerdb.menu.entity.MenuImage;
+import com.nowait.domaincorerdb.menu.exception.MenuCreationUnauthorizedException;
+import com.nowait.domaincorerdb.menu.exception.MenuDeleteUnauthorizedException;
 import com.nowait.domaincorerdb.menu.exception.MenuNotFoundException;
+import com.nowait.domaincorerdb.menu.exception.MenuParamEmptyException;
+import com.nowait.domaincorerdb.menu.exception.MenuUpdateUnauthorizedException;
+import com.nowait.domaincorerdb.menu.exception.MenuViewUnauthorizedException;
 import com.nowait.domaincorerdb.menu.repository.MenuImageRepository;
 import com.nowait.domaincorerdb.menu.repository.MenuRepository;
-import com.nowait.domaincorerdb.order.exception.OrderParameterEmptyException;
+import com.nowait.domaincorerdb.user.entity.MemberDetails;
+import com.nowait.domaincorerdb.user.entity.User;
+import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
+import com.nowait.domaincorerdb.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,18 +35,31 @@ public class MenuService {
 
 	private final MenuRepository menuRepository;
 	private final MenuImageRepository menuImageRepository;
+	private final UserRepository userRepository;
 
 	@Transactional
-	public MenuCreateResponse createMenu(MenuCreateRequest request) {
-		Menu toSave = request.toEntity();
+	public MenuCreateResponse createMenu(MenuCreateRequest request, MemberDetails memberDetails) {
+		// 사용자 정보 가져오기
+		User user = userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
 
+		// 사용자 역할이 SUPER_ADMIN이거나, storeId가 일치하는지 확인
+		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(request.getStoreId())) {
+			throw new MenuCreationUnauthorizedException();
+		}
+		// 메뉴 생성 로직
+		Menu toSave = request.toEntity();
 		Menu saved = menuRepository.save(toSave);
 
 		return MenuCreateResponse.fromEntity(saved);
 	}
 
 	@Transactional(readOnly = true)
-	public MenuReadResponse getAllMenusByStoreId(Long storeId) {
+	public MenuReadResponse getAllMenusByStoreId(Long storeId, MemberDetails memberDetails) {
+		// 사용자 정보 가져오기
+		User user = userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
+
+		// 사용자 역할이 SUPER_ADMIN이거나, storeId가 일치하는지 확인
+		validateMenuViewAuthorization(user, storeId);
 		List<Menu> menus = menuRepository.findAllByStoreIdAndDeletedFalse(storeId);
 
 		List<MenuReadDto> menuReadResponse = menus.stream()
@@ -54,13 +76,16 @@ public class MenuService {
 	}
 
 	@Transactional(readOnly = true)
-	public MenuReadDto getMenuById(Long storeId, Long menuId) {
+	public MenuReadDto getMenuById(Long storeId, Long menuId, MemberDetails memberDetails) {
 		if (storeId == null || menuId == null) {
-			throw new OrderParameterEmptyException();
+			throw new MenuParamEmptyException();
 		}
-
+		// 사용자 정보 가져오기
+		User user = userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
 		Menu menu = menuRepository.findByStoreIdAndIdAndDeletedFalse(storeId, menuId)
 			.orElseThrow(MenuNotFoundException::new);
+		// 사용자 역할이 SUPER_ADMIN이거나, storeId가 일치하는지 확인
+		validateMenuViewAuthorization(user, menu.getStoreId());
 
 		List<MenuImage> images = menuImageRepository.findByMenu(menu);
 		List<MenuImageUploadResponse> imageDto = images.stream()
@@ -68,13 +93,18 @@ public class MenuService {
 			.toList();
 
 		return MenuReadDto.fromEntity(menu, imageDto);
+
 	}
 
-
 	@Transactional
-	public MenuReadDto updateMenu(Long menuId, MenuUpdateRequest request) {
+	public MenuReadDto updateMenu(Long menuId, MenuUpdateRequest request, MemberDetails memberDetails) {
+		User user = userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
 		Menu menu = menuRepository.findByIdAndDeletedFalse(menuId)
 			.orElseThrow(MenuNotFoundException::new);
+
+		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(menu.getStoreId())) {
+			throw new MenuUpdateUnauthorizedException();
+		}
 
 		menu.updateInfo(
 			request.getName(),
@@ -93,10 +123,13 @@ public class MenuService {
 	}
 
 	@Transactional
-	public String deleteMenu(Long menuId) {
-		Menu menu = menuRepository.findById(menuId)
-			.orElseThrow(MenuNotFoundException::new);
+	public String deleteMenu(Long menuId, MemberDetails memberDetails) {
+		User user = userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
+		Menu menu = menuRepository.findById(menuId).orElseThrow(MenuNotFoundException::new);
 
+		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(menu.getStoreId())) {
+			throw new MenuDeleteUnauthorizedException();
+		}
 		menu.markAsDeleted();
 		menuRepository.save(menu);
 
@@ -111,6 +144,12 @@ public class MenuService {
 		menu.toggleSoldOut();
 		menuRepository.save(menu);
 		return menu.getIsSoldOut();
+	}
+
+	private static void validateMenuViewAuthorization(User user, Long storeId) {
+		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(storeId)) {
+			throw new MenuViewUnauthorizedException();
+		}
 	}
 
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/user/dto/ManagerSignupRequestDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/user/dto/ManagerSignupRequestDto.java
@@ -7,6 +7,7 @@ import com.nowait.domaincorerdb.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,22 +19,25 @@ public class ManagerSignupRequestDto {
 	@NotBlank
 	@Email(regexp = "^(?=.{1,64}@)[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*@"
 		+ "[^-][A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z]{2,})$")
-	@Schema(description = "이메일", example = "abc@gmail.com")
+	@Schema(description = "이메일(예시)", example = "abc@gmail.com")
 	private String email;
 
 	@NotBlank
 	@Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}")
-	@Schema(description = "비밀번호", example = "1234568!@")
+	@Schema(description = "비밀번호(예시)", example = "1234568!@")
 	private String password;
 
 	@NotBlank
 	@Pattern(regexp = "^[a-zA-Z가-힣]{2,12}$")
-	@Schema(description = "닉네임", example = "가십이")
+	@Schema(description = "이름(예시)", example = "김노웻")
 	private String nickname;
 
-	@NotBlank
 	@Schema(description = "로그인타입", example = "LOCAL")
 	private String socialType;
+
+	@NotNull
+	@Schema(description = "관리자가 속한 storeId", example = "1")
+	private Long storeId;
 
 	public User toEntity() {
 		return User.builder()
@@ -42,6 +46,7 @@ public class ManagerSignupRequestDto {
 			.nickname(nickname)
 			.socialType(SocialType.LOCAL)
 			.role(Role.MANAGER)
+			.storeId(storeId)
 			.build();
 
 	}

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/security/jwt/JwtAuthorizationFilter.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/security/jwt/JwtAuthorizationFilter.java
@@ -79,7 +79,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		}
 
 		User user = User.createUserWithId(userId, "sampleEmail", "sampleNickname", "sampleProfileImg"
-			, SocialType.KAKAO, Role.fromString(roleString));
+			, SocialType.KAKAO, Role.fromString(roleString),5000L);
 
 		CustomOAuth2User customOAuth2User = new CustomOAuth2User(user);
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/controller/TokenController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/controller/TokenController.java
@@ -42,7 +42,7 @@ public class TokenController {
 
         long currentAccessTokenExpiration = accessTokenExpiration;
         if (role.equals("SUPER_ADMIN")) {
-            currentAccessTokenExpiration = 7L * 24 * 60 * 60 * 1000L; // 7일
+            currentAccessTokenExpiration = 100L * 24 * 60 * 60 * 1000L; // 100일
         }
 
         // 리프레시 토큰 유효성 검증

--- a/nowait-common/src/main/java/com/nowait/common/exception/ErrorMessage.java
+++ b/nowait-common/src/main/java/com/nowait/common/exception/ErrorMessage.java
@@ -29,7 +29,11 @@ public enum ErrorMessage {
 
 	// menu
 	MENU_PARAMETER_EMPTY("메뉴 생성 시 파라미터 정보가 없습니다.", "menu001"),
-	MENU_NOT_FOUND("해당 메뉴를 찾을 수 없습니다.", "menu001"),
+	MENU_NOT_FOUND("해당 메뉴를 찾을 수 없습니다.", "menu002"),
+	MENU_CREATION_UNAUTHORIZED("메뉴 생성 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "menu003"),
+	MENU_VIEW_UNAUTHORIZED("메뉴 보기 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "menu004"),
+	MENU_UPDATE_UNAUTHORIZED("메뉴 수정 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "menu005"),
+	MENU_DELETE_UNAUTHORIZED("메뉴 삭제 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "menu006"),
 
 	// store
 	STORE_PARAMETER_EMPTY("주점 생성 시 파라미터 정보가 없습니다.", "store001"),

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuCreationUnauthorizedException.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuCreationUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.nowait.domaincorerdb.menu.exception;
+
+import com.nowait.common.exception.ErrorMessage;
+
+public class MenuCreationUnauthorizedException extends RuntimeException {
+	public MenuCreationUnauthorizedException() {
+		super(ErrorMessage.MENU_CREATION_UNAUTHORIZED.getMessage());
+	}
+}

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuDeleteUnauthorizedException.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuDeleteUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.nowait.domaincorerdb.menu.exception;
+
+import com.nowait.common.exception.ErrorMessage;
+
+public class MenuDeleteUnauthorizedException extends RuntimeException {
+	public MenuDeleteUnauthorizedException() {
+		super(ErrorMessage.MENU_DELETE_UNAUTHORIZED.getMessage());
+	}
+}

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuUpdateUnauthorizedException.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuUpdateUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.nowait.domaincorerdb.menu.exception;
+
+import com.nowait.common.exception.ErrorMessage;
+
+public class MenuUpdateUnauthorizedException extends RuntimeException {
+	public MenuUpdateUnauthorizedException() {
+		super(ErrorMessage.MENU_UPDATE_UNAUTHORIZED.getMessage());
+	}
+}

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuViewUnauthorizedException.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/exception/MenuViewUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.nowait.domaincorerdb.menu.exception;
+
+import com.nowait.common.exception.ErrorMessage;
+
+public class MenuViewUnauthorizedException extends RuntimeException {
+	public MenuViewUnauthorizedException() {
+		super(ErrorMessage.MENU_VIEW_UNAUTHORIZED.getMessage());
+	}
+}

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/user/entity/User.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/user/entity/User.java
@@ -44,23 +44,29 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private Long storeId;
+
     @Builder
-    public User(String email,String password, String nickname, String profileImage, SocialType socialType, Role role){
+    public User(String email,String password, String nickname, String profileImage, SocialType socialType,
+        Role role, Long storeId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.socialType = socialType;
         this.role = role;
+        this.storeId = storeId;
     }
 
-    public static User createUserWithId(Long userId, String email, String nickname, String profileImage, SocialType socialType, Role role){
+    public static User createUserWithId(Long userId, String email, String nickname, String profileImage,
+        SocialType socialType, Role role, Long storeId) {
         User user = User.builder()
             .email(email)
             .nickname(nickname)
             .profileImage(profileImage)
             .socialType(socialType)
             .role(role)
+            .storeId(storeId)
             .build();
         user.id = userId;
 


### PR DESCRIPTION
## 작업 요약
- 본인 store외 접근 제한 로직 추가
- 예외처리 상세화
## Issue Link
#62 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 메뉴 생성, 조회, 수정, 삭제 시 사용자 권한 검증 및 접근 제어가 추가되었습니다.
  * 메뉴 관련 권한이 없을 경우 명확한 에러 메시지와 함께 403 Forbidden 응답이 제공됩니다.
  * 매니저 회원가입 시 매장 ID 입력이 필수로 변경되었습니다.

* **버그 수정**
  * 메뉴 관련 파라미터 검증이 더욱 구체적으로 개선되었습니다.

* **기타 변경**
  * SUPER_ADMIN 역할의 액세스 토큰 유효기간이 7일에서 100일로 연장되었습니다.
  * 사용자 정보에 storeId 필드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->