### PR TITLE
feat(User,Token): 리프레시 토큰 중복 저장 로직 수정

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/token/service/TokenService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/token/service/TokenService.java
@@ -58,9 +58,6 @@ public class TokenService {
             throw new TokenBadRequestException(); // 400
         }
 
-        // 기존 토큰 삭제 및 새 토큰 저장
-        tokenRepository.delete(token);
-        Token newToken = Token.toEntity(token.getUser(), newRefreshToken, LocalDateTime.now().plusDays(30));
-        tokenRepository.save(newToken);
+        token.updateRefreshToken(newRefreshToken, LocalDateTime.now().plusDays(30));
     }
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/controller/TokenController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/controller/TokenController.java
@@ -5,13 +5,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nowait.applicationuser.security.jwt.JwtUtil;
 import com.nowait.applicationuser.token.dto.AuthenticationResponse;
-import com.nowait.applicationuser.token.dto.RefreshTokenRequest;
 import com.nowait.applicationuser.token.service.TokenService;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/service/TokenService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/service/TokenService.java
@@ -58,8 +58,6 @@ public class TokenService {
         }
 
         // 기존 토큰 삭제 및 새 토큰 저장
-        tokenRepository.delete(token);
-        Token newToken = Token.toEntity(token.getUser(), newRefreshToken, LocalDateTime.now().plusDays(30));
-        tokenRepository.save(newToken);
+        token.updateRefreshToken(newRefreshToken, LocalDateTime.now().plusDays(30));
     }
 }


### PR DESCRIPTION
## 작업 요약

## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 리프레시 토큰 갱신 시 기존 토큰을 삭제 후 새로 생성하는 방식에서, 기존 토큰 정보를 직접 업데이트하는 방식으로 변경하여 처리 과정이 간소화되었습니다.

* **정리**
  * 사용되지 않는 import 구문이 제거되어 코드가 더 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->