### PR TITLE
feat(Reservation): 예약 중복 등록 방지

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/exception/GlobalExceptionHandler.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/exception/GlobalExceptionHandler.java
@@ -28,6 +28,7 @@ import com.nowait.domaincorerdb.order.exception.OrderItemsEmptyException;
 import com.nowait.domaincorerdb.order.exception.OrderParameterEmptyException;
 import com.nowait.domaincorerdb.reservation.exception.DuplicateReservationException;
 import com.nowait.domaincorerdb.reservation.exception.ReservationNotFoundException;
+import com.nowait.domaincorerdb.store.exception.StoreWaitingDisabledException;
 import com.nowait.domaincorerdb.token.exception.BusinessException;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
 import com.nowait.domainuserrdb.bookmark.exception.BookmarkOwnerMismatchException;
@@ -168,6 +169,13 @@ public class GlobalExceptionHandler {
 	public ErrorResponse duplicateReservationException(DuplicateReservationException e) {
 		log.error("duplicateReservationException", e);
 		return new ErrorResponse(e.getMessage(), DUPLICATE_RESERVATION.getCode());
+	}
+
+	@ResponseStatus(value = BAD_REQUEST)
+	@ExceptionHandler(StoreWaitingDisabledException.class)
+	public ErrorResponse storeWaitingDisabledException(StoreWaitingDisabledException e) {
+		log.error("storeWaitingDisabledException", e);
+		return new ErrorResponse(e.getMessage(), STORE_WAITING_DISABLED.getCode());
 	}
 
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/exception/GlobalExceptionHandler.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/exception/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import com.nowait.domaincorerdb.order.exception.DepositorNameTooLongException;
 import com.nowait.domaincorerdb.order.exception.DuplicateOrderException;
 import com.nowait.domaincorerdb.order.exception.OrderItemsEmptyException;
 import com.nowait.domaincorerdb.order.exception.OrderParameterEmptyException;
+import com.nowait.domaincorerdb.reservation.exception.DuplicateReservationException;
 import com.nowait.domaincorerdb.reservation.exception.ReservationNotFoundException;
 import com.nowait.domaincorerdb.token.exception.BusinessException;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
@@ -160,6 +161,13 @@ public class GlobalExceptionHandler {
 	public ErrorResponse reservationNotFoundException(ReservationNotFoundException e) {
 		log.error("reservationNotFoundException", e);
 		return new ErrorResponse(e.getMessage(), NOTFOUND_RESERVATION.getCode());
+	}
+
+	@ResponseStatus(value = BAD_REQUEST)
+	@ExceptionHandler(DuplicateReservationException.class)
+	public ErrorResponse duplicateReservationException(DuplicateReservationException e) {
+		log.error("duplicateReservationException", e);
+		return new ErrorResponse(e.getMessage(), DUPLICATE_RESERVATION.getCode());
 	}
 
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/oauth/oauth2/CustomOAuth2UserService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/oauth/oauth2/CustomOAuth2UserService.java
@@ -54,6 +54,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 				.profileImage(oAuth2Response.getProfileImage())
 				.socialType(SocialType.KAKAO)
 				.role(Role.USER) // 일반 유저 설정
+				.storeId(0L)
 				.build();
 
 			userRepository.save(user);

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
@@ -10,6 +10,7 @@ import com.nowait.applicationuser.reservation.dto.ReservationCreateRequestDto;
 import com.nowait.applicationuser.reservation.dto.ReservationCreateResponseDto;
 import com.nowait.common.enums.ReservationStatus;
 import com.nowait.domaincorerdb.reservation.entity.Reservation;
+import com.nowait.domaincorerdb.reservation.exception.DuplicateReservationException;
 import com.nowait.domaincorerdb.reservation.repository.ReservationRepository;
 import com.nowait.domaincorerdb.store.entity.Store;
 import com.nowait.domaincorerdb.store.exception.StoreNotFoundException;
@@ -18,7 +19,6 @@ import com.nowait.domaincorerdb.user.entity.User;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
 import com.nowait.domaincorerdb.user.repository.UserRepository;
 import com.nowait.domainuserrdb.oauth.dto.CustomOAuth2User;
-import com.sun.jdi.request.DuplicateRequestException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,7 +45,7 @@ public class ReservationService {
 			List.of(ReservationStatus.WAITING, ReservationStatus.CALLING)
 		);
 		if (hasOngoingReservation) {
-			throw new DuplicateRequestException();
+			throw new DuplicateReservationException();
 		}
 		Reservation reservation = Reservation.builder()
 			.store(store)

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
@@ -1,6 +1,7 @@
 package com.nowait.applicationuser.reservation.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,11 +12,13 @@ import com.nowait.common.enums.ReservationStatus;
 import com.nowait.domaincorerdb.reservation.entity.Reservation;
 import com.nowait.domaincorerdb.reservation.repository.ReservationRepository;
 import com.nowait.domaincorerdb.store.entity.Store;
+import com.nowait.domaincorerdb.store.exception.StoreNotFoundException;
 import com.nowait.domaincorerdb.store.repository.StoreRepository;
 import com.nowait.domaincorerdb.user.entity.User;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
 import com.nowait.domaincorerdb.user.repository.UserRepository;
 import com.nowait.domainuserrdb.oauth.dto.CustomOAuth2User;
+import com.sun.jdi.request.DuplicateRequestException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,10 +34,19 @@ public class ReservationService {
 	public ReservationCreateResponseDto create(Long storeId, CustomOAuth2User customOAuth2User,
 		ReservationCreateRequestDto requestDto) {
 		Store store = storeRepository.findById(storeId)
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 store"));
+			.orElseThrow(StoreNotFoundException::new);
 		User user = userRepository.findById(customOAuth2User.getUserId())
 			.orElseThrow(UserNotFoundException::new);
 
+		// 중복 예약 존재 여부 확인
+		boolean hasOngoingReservation = reservationRepository.existsByUserAndStoreAndStatusIn(
+			user,
+			store,
+			List.of(ReservationStatus.WAITING, ReservationStatus.CALLING)
+		);
+		if (hasOngoingReservation) {
+			throw new DuplicateRequestException();
+		}
 		Reservation reservation = Reservation.builder()
 			.store(store)
 			.user(user)

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
@@ -14,6 +14,7 @@ import com.nowait.domaincorerdb.reservation.exception.DuplicateReservationExcept
 import com.nowait.domaincorerdb.reservation.repository.ReservationRepository;
 import com.nowait.domaincorerdb.store.entity.Store;
 import com.nowait.domaincorerdb.store.exception.StoreNotFoundException;
+import com.nowait.domaincorerdb.store.exception.StoreWaitingDisabledException;
 import com.nowait.domaincorerdb.store.repository.StoreRepository;
 import com.nowait.domaincorerdb.user.entity.User;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
@@ -37,7 +38,9 @@ public class ReservationService {
 			.orElseThrow(StoreNotFoundException::new);
 		User user = userRepository.findById(customOAuth2User.getUserId())
 			.orElseThrow(UserNotFoundException::new);
-
+		// store 웨이팅 비활성화 여부
+		if (Boolean.FALSE.equals(store.getIsActive()))
+			throw new StoreWaitingDisabledException();
 		// 중복 예약 존재 여부 확인
 		boolean hasOngoingReservation = reservationRepository.existsByUserAndStoreAndStatusIn(
 			user,

--- a/nowait-common/src/main/java/com/nowait/common/exception/ErrorMessage.java
+++ b/nowait-common/src/main/java/com/nowait/common/exception/ErrorMessage.java
@@ -47,6 +47,7 @@ public enum ErrorMessage {
 	STORE_VIEW_UNAUTHORIZED("주점 보기 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "store003"),
 	STORE_UPDATE_UNAUTHORIZED("주점 수정 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "store004"),
 	STORE_DELETE_UNAUTHORIZED("주점 삭제 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "store005"),
+	STORE_WAITING_DISABLED("해당 주점은 대기 비활성화된 주점입니다.", "store006"),
 
 	// image
 	IMAGE_FILE_EMPTY("이미지 파일을 업로드 해주세요", "image001"),

--- a/nowait-common/src/main/java/com/nowait/common/exception/ErrorMessage.java
+++ b/nowait-common/src/main/java/com/nowait/common/exception/ErrorMessage.java
@@ -27,6 +27,7 @@ public enum ErrorMessage {
 	NOTFOUND_RESERVATION("저장된 예약 정보가 없습니다.", "reservation001"),
 	RESERVATION_VIEW_UNAUTHORIZED("예약 보기 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "reservation002"),
 	RESERVATION_UPDATE_UNAUTHORIZED("예약 수정 권한이 없습니다.(슈퍼계정 or 주점 관리자만 가능)", "reservation003"),
+	DUPLICATE_RESERVATION("이미 대기 중인 예약이 존재합니다.", "reservation004"),
 
 	// bookmark
 	DUPLICATE_BOOKMARK("이미 북마크한 주점입니다.", "bookmark001"),

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/exception/DuplicateReservationException.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/exception/DuplicateReservationException.java
@@ -1,0 +1,10 @@
+package com.nowait.domaincorerdb.reservation.exception;
+
+import com.nowait.common.exception.ErrorMessage;
+
+public class DuplicateReservationException extends RuntimeException {
+	public DuplicateReservationException() {
+		super(ErrorMessage.DUPLICATE_RESERVATION.getMessage());
+	}
+}
+

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
@@ -5,9 +5,14 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.nowait.common.enums.ReservationStatus;
 import com.nowait.domaincorerdb.reservation.entity.Reservation;
+import com.nowait.domaincorerdb.store.entity.Store;
+import com.nowait.domaincorerdb.user.entity.User;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 	List<Reservation> findAllByStore_StoreIdOrderByRequestedAtAsc(Long storeId);
+	boolean existsByUserAndStoreAndStatusIn(User user, Store store, List<ReservationStatus> statuses);
+
 }

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/exception/StoreWaitingDisabledException.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/exception/StoreWaitingDisabledException.java
@@ -1,0 +1,9 @@
+package com.nowait.domaincorerdb.store.exception;
+
+import com.nowait.common.exception.ErrorMessage;
+
+public class StoreWaitingDisabledException extends RuntimeException {
+	public StoreWaitingDisabledException() {
+		super(ErrorMessage.STORE_WAITING_DISABLED.getMessage());
+	}
+}


### PR DESCRIPTION
## 작업 요약

## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 중복 예약 시도를 방지하는 기능이 추가되었습니다. 동일한 사용자와 매장에 대해 대기 중인 예약이 이미 존재하면 예약이 생성되지 않습니다.
  * 대기 기능이 비활성화된 매장에 대한 예약 시도 시 명확한 오류 메시지가 제공됩니다.

* **버그 수정**
  * 매장을 찾을 수 없는 경우, 더 명확한 오류 메시지와 예외 처리가 제공됩니다.

* **개선 사항**
  * 카카오 로그인 시 신규 사용자 등록 시 storeId가 기본값(0)으로 초기화됩니다.
  * 중복 예약 및 대기 비활성화 관련 오류 발생 시 사용자에게 명확한 오류 메시지와 코드가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->