### PR TITLE
Feat: 배포 스크립트 수정

### DIFF
--- a/.github/workflows/deploy-admin-docker.yml
+++ b/.github/workflows/deploy-admin-docker.yml
@@ -69,7 +69,7 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: Copy Docker Compose File
-          uses: appleboy/scp-action@v0.1.7
+          uses: appleboy/ssh-action@master
           with:
             host: ${{ secrets.EC2_HOST }}
             username: ubuntu

--- a/nowait-app-admin-api/src/main/java/com/nowait/ApiAdminApplication.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/ApiAdminApplication.java
@@ -10,4 +10,3 @@ public class ApiAdminApplication {
 		org.springframework.boot.SpringApplication.run(ApiAdminApplication.class, args);
 	}
 }
-


### PR DESCRIPTION
## 작업 요약
- ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain 에러 수정을 위한 스크립트 수정

## Issue Link
#58 
## 문제점 및 어려움

## 해결 방안

## Reference
https://github.com/appleboy/ssh-action/issues/297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 자동화 워크플로우의 파일 전송 방식을 개선했습니다.

* **Style**
  * 코드 파일의 불필요한 공백을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->