### PR TITLE
Feat: 주점 프로필 사진 업로드 기능 추가

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/controller/StoreImageController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/controller/StoreImageController.java
@@ -40,19 +40,8 @@ public class StoreImageController {
 		@RequestParam("files") List<MultipartFile> files
 	) {
 		// TODO 관련 정책 확정되면 메서드로 분리 예정
-		// 파일 개수 제한 검증
-		if (files.isEmpty() || files.size() > 10) {
-			throw new IllegalArgumentException("파일은 1개 이상 10개 이하로 업로드해 주세요.");
-		}
 		// 파일 크기 검증
-		for (MultipartFile file : files) {
-			if (file.isEmpty()) {
-				throw new IllegalArgumentException("빈 파일은 업로드할 수 없습니다.");
-			}
-			if (file.getSize() > 10 * 1024 * 1024) { // 10MB 제한
-				throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
-			}
-		}
+		validateFiles(files);
 
 		List<StoreImageUploadResponse> response = storeImageService.saveAll(storeId, files);
 		return ResponseEntity
@@ -74,12 +63,7 @@ public class StoreImageController {
 		@PathVariable Long storeId,
 		@RequestParam("file") MultipartFile file
 	) {
-		if (file == null || file.isEmpty()) {
-			throw new IllegalArgumentException("빈 파일은 업로드할 수 없습니다.");
-		}
-		if (file.getSize() > 10 * 1024 * 1024) { // 10MB 제한
-			throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
-		}
+		validateFileSize(file);
 
 		StoreImageUploadResponse response = storeImageService.saveProfileImage(storeId, file);
 		return ResponseEntity
@@ -107,5 +91,23 @@ public class StoreImageController {
 						"Store image deleted successfully."
 					)
 			);
+	}
+
+	private void validateFileSize(MultipartFile file) {
+		if (file == null || file.isEmpty()) {
+			throw new IllegalArgumentException("빈 파일은 업로드할 수 없습니다.");
+		}
+		if (file.getSize() > 10 * 1024 * 1024) { // 10MB 제한
+			throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+		}
+	}
+
+	private void validateFiles(List<MultipartFile> files) {
+		if (files.isEmpty() || files.size() > 10) {
+			throw new IllegalArgumentException("파일은 1개 이상 10개 이하로 업로드해 주세요.");
+		}
+		for (MultipartFile file : files) {
+			validateFileSize(file);
+		}
 	}
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/controller/StoreImageController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/controller/StoreImageController.java
@@ -29,7 +29,7 @@ public class StoreImageController {
 
 	private final StoreImageService storeImageService;
 
-	@PostMapping("/store-images/{storeId}")
+	@PostMapping("/banner-images/{storeId}")
 	@Operation(
 		summary = "주점 이미지 업로드",
 		description = "주점에 이미지를 업로드합니다. 최대 10개의 이미지 파일을 업로드할 수 있습니다."
@@ -55,6 +55,33 @@ public class StoreImageController {
 		}
 
 		List<StoreImageUploadResponse> response = storeImageService.saveAll(storeId, files);
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
+	}
+
+	@PostMapping("/profile-images/{storeId}")
+	@Operation(
+		summary = "주점 프로필 이미지 업로드",
+		description = "주점의 프로필 이미지를 업로드합니다. 단일 이미지 파일을 업로드할 수 있습니다."
+	)
+	@ApiResponse(responseCode = "201", description = "주점 프로필 이미지 업로드 성공")
+	public ResponseEntity<?> uploadStoreProfileImage(
+		@PathVariable Long storeId,
+		@RequestParam("file") MultipartFile file
+	) {
+		if (file == null || file.isEmpty()) {
+			throw new IllegalArgumentException("빈 파일은 업로드할 수 없습니다.");
+		}
+		if (file.getSize() > 10 * 1024 * 1024) { // 10MB 제한
+			throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+		}
+
+		StoreImageUploadResponse response = storeImageService.saveProfileImage(storeId, file);
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/dto/StoreImageUploadResponse.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/dto/StoreImageUploadResponse.java
@@ -1,5 +1,6 @@
 package com.nowait.applicationadmin.store.dto;
 
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.StoreImage;
 
 import lombok.Builder;
@@ -10,11 +11,13 @@ import lombok.Getter;
 public class StoreImageUploadResponse {
 	private final Long id;
 	private final String imageUrl;
+	private final ImageType imageType;
 
 	public static StoreImageUploadResponse fromEntity(StoreImage storeImage) {
 		return StoreImageUploadResponse.builder()
 			.id(storeImage.getId())
 			.imageUrl(storeImage.getImageUrl())
+			.imageType(storeImage.getImageType())
 			.build();
 	}
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/dto/StoreReadDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/dto/StoreReadDto.java
@@ -3,6 +3,7 @@ package com.nowait.applicationadmin.store.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.Store;
 
 import lombok.AllArgsConstructor;
@@ -18,12 +19,23 @@ public class StoreReadDto {
 	private String name;
 	private String location;
 	private String description;
-	private List<StoreImageUploadResponse> images;
+	private StoreImageUploadResponse profileImage;
+	private List<StoreImageUploadResponse> bannerImages;
 	private Boolean isActive;
 	private Boolean deleted;
 	private LocalDateTime createdAt;
 
-	public static StoreReadDto fromEntity(Store store, List<StoreImageUploadResponse> images) {
+	public static StoreReadDto fromEntity(Store store, List<StoreImageUploadResponse> allImages) {
+
+		StoreImageUploadResponse profile = allImages.stream()
+			.filter(image -> image.getImageType() == ImageType.PROFILE)
+			.findFirst()
+			.orElse(null);
+
+		List<StoreImageUploadResponse> banners = allImages.stream()
+			.filter(image -> image.getImageType() == ImageType.BANNER)
+			.toList();
+
 		return StoreReadDto.builder()
 			.createdAt(store.getCreatedAt())
 			.storeId(store.getStoreId())
@@ -33,7 +45,8 @@ public class StoreReadDto {
 			.description(store.getDescription())
 			.isActive(store.getIsActive())
 			.deleted(store.getDeleted())
-			.images(images)
+			.profileImage(profile)
+			.bannerImages(banners)
 			.build();
 	}
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/service/StoreImageService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/service/StoreImageService.java
@@ -2,6 +2,7 @@ package com.nowait.applicationadmin.store.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.nowait.applicationadmin.store.dto.StoreImageUploadResponse;
 
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.Store;
 import com.nowait.domaincorerdb.store.entity.StoreImage;
 import com.nowait.domaincorerdb.store.exception.StoreImageEmptyException;
@@ -31,7 +33,8 @@ public class StoreImageService {
 
 	@Transactional
 	public List<StoreImageUploadResponse> saveAll(Long storeId, List<MultipartFile> files) {
-		if (files == null || files.isEmpty()) throw new StoreImageEmptyException();
+		if (files == null || files.isEmpty())
+			throw new StoreImageEmptyException();
 
 		String type = "store";
 		Store store = storeRepository.findById(storeId)
@@ -60,6 +63,7 @@ public class StoreImageService {
 				.store(store)
 				.imageUrl(uploadResult.url())
 				.fileKey(uploadResult.key())
+				.imageType(ImageType.BANNER)
 				.build();
 
 			storeImageRepository.save(storeImage);
@@ -67,6 +71,36 @@ public class StoreImageService {
 		}
 
 		return imageUploadResponses;
+	}
+
+	@Transactional
+	public StoreImageUploadResponse saveProfileImage(Long storeId, MultipartFile file) {
+
+		String type = "store";
+		Store store = storeRepository.findById(storeId)
+			.orElseThrow(StoreNotFoundException::new);
+
+		Optional<StoreImage> existingProfileImage = storeImageRepository.findByStoreStoreIdAndImageType(store.getStoreId(),
+			ImageType.PROFILE);
+
+		existingProfileImage.ifPresent(profile -> {
+			s3Service.delete(profile.getFileKey());
+			storeImageRepository.delete(profile);
+		});
+
+		S3Service.S3UploadResult uploadResult = s3Service.upload(type, storeId, file).join();
+
+		// StoreImage 엔티티 생성 및 저장
+		StoreImage storeImage = StoreImage.builder()
+			.store(store)
+			.imageUrl(uploadResult.url())
+			.fileKey(uploadResult.key())
+			.imageType(ImageType.PROFILE)
+			.build();
+
+		storeImageRepository.save(storeImage);
+
+		return StoreImageUploadResponse.fromEntity(storeImage);
 	}
 
 	@Transactional

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/controller/StoreController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/controller/StoreController.java
@@ -27,7 +27,6 @@ public class StoreController {
 
 	private final StoreService storeService;
 
-
 	@GetMapping("/all-stores")
 	@Operation(summary = "모든 주점 조회", description = "모든 주점을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "모든 주점 조회 성공")
@@ -50,7 +49,11 @@ public class StoreController {
 	public ResponseEntity<?> getAllStores(Pageable pageable) {
 		return ResponseEntity
 			.ok()
-			.body(ApiUtils.success(storeService.getAllStoresByPage(pageable)));
+			.body(
+				ApiUtils.success(
+					storeService.getAllStoresByPage(pageable)
+				)
+			);
 	}
 
 	@GetMapping("/{storeId}")

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StoreImageUploadResponse.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StoreImageUploadResponse.java
@@ -1,5 +1,6 @@
 package com.nowait.applicationuser.store.dto;
 
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.StoreImage;
 
 import lombok.Builder;
@@ -10,11 +11,13 @@ import lombok.Getter;
 public class StoreImageUploadResponse {
 	private final Long id;
 	private final String imageUrl;
+	private final ImageType imageType;
 
 	public static StoreImageUploadResponse fromEntity(StoreImage storeImage) {
 		return StoreImageUploadResponse.builder()
 			.id(storeImage.getId())
 			.imageUrl(storeImage.getImageUrl())
+			.imageType(storeImage.getImageType())
 			.build();
 	}
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StoreReadDto.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StoreReadDto.java
@@ -3,6 +3,7 @@ package com.nowait.applicationuser.store.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.Store;
 
 import lombok.AllArgsConstructor;
@@ -18,12 +19,23 @@ public class StoreReadDto {
 	private String name;
 	private String location;
 	private String description;
-	private List<StoreImageUploadResponse> images;
+	private StoreImageUploadResponse profileImage;
+	private List<StoreImageUploadResponse> bannerImages;
 	private Boolean isActive;
 	private Boolean deleted;
 	private LocalDateTime createdAt;
 
-	public static StoreReadDto fromEntity(Store store, List<StoreImageUploadResponse> images) {
+	public static StoreReadDto fromEntity(Store store, List<StoreImageUploadResponse> allImages) {
+
+		StoreImageUploadResponse profile = allImages.stream()
+			.filter(image -> image.getImageType() == ImageType.PROFILE)
+			.findFirst()
+			.orElse(null);
+
+		List<StoreImageUploadResponse> banners = allImages.stream()
+			.filter(image -> image.getImageType() == ImageType.BANNER)
+			.toList();
+
 		return StoreReadDto.builder()
 			.createdAt(store.getCreatedAt())
 			.storeId(store.getStoreId())
@@ -33,7 +45,8 @@ public class StoreReadDto {
 			.description(store.getDescription())
 			.isActive(store.getIsActive())
 			.deleted(store.getDeleted())
-			.images(images)
+			.profileImage(profile)
+			.bannerImages(banners)
 			.build();
 	}
 }

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/entity/ImageType.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/entity/ImageType.java
@@ -12,7 +12,10 @@ public enum ImageType {
 	PROFILE("프로필 사진"),
 
 	@Schema(description = "주점 배너 사진")
-	BANNER("배너 사진");
+	BANNER("배너 사진"),
+
+	@Schema(description = "주점 배너 사진")
+	NONE("이미지 없음");
 
 	private final String description;
 }

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/entity/ImageType.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/entity/ImageType.java
@@ -1,0 +1,18 @@
+package com.nowait.domaincorerdb.store.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "이미지 타입 Enum")
+public enum ImageType {
+	@Schema(description = "주점 프로필 사진")
+	PROFILE("프로필 사진"),
+
+	@Schema(description = "주점 배너 사진")
+	BANNER("배너 사진");
+
+	private final String description;
+}

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/entity/StoreImage.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/entity/StoreImage.java
@@ -4,6 +4,8 @@ import com.nowait.domaincorerdb.base.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,4 +38,8 @@ public class StoreImage extends BaseTimeEntity {
 
 	@Column(nullable = false, length = 500)
 	private String fileKey;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private ImageType imageType;
 }

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/repository/StoreImageRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/repository/StoreImageRepository.java
@@ -1,10 +1,12 @@
 package com.nowait.domaincorerdb.store.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.Store;
 import com.nowait.domaincorerdb.store.entity.StoreImage;
 
@@ -12,4 +14,6 @@ import com.nowait.domaincorerdb.store.entity.StoreImage;
 public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
 
 	List<StoreImage> findByStore(Store store);
+
+	Optional<StoreImage> findByStoreStoreIdAndImageType(Long storeId, ImageType imageType);
 }


### PR DESCRIPTION
## 작업 요약
- 주점 프로필 업로드 기능 추가 
- 기존 주점 이미지 업로드 api는 배너 이미지 업로드용으로 사용 & api 경로 수정
- 프로필 업로드 기능 추가로 인한 주점 조회 response 객체 변경 -> profileImage와 bannerImages 그룹핑
## Issue Link
#112 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매장 프로필 이미지 업로드 전용 엔드포인트가 추가되었습니다. (최대 10MB, 1장)
  * 이미지 업로드 응답에 이미지 타입 정보가 포함됩니다.
  * 매장 정보 조회 시 프로필 이미지와 배너 이미지가 각각 분리되어 제공됩니다.

* **기능 개선**
  * 기존 배너 이미지 업로드 경로가 `/store-images/{storeId}`에서 `/banner-images/{storeId}`로 변경되었습니다.

* **기타**
  * 이미지 타입(PROFILE, BANNER, NONE) 구분이 도입되어 이미지 관리가 명확해졌습니다.
  * 프로필 이미지 업로드 시 기존 이미지가 자동 삭제되어 중복 관리 방지가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->