### PR TITLE
refactor: 응답 객체에 프로필 이미지 url 포함

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/dto/StoreRankingDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/dto/StoreRankingDto.java
@@ -11,9 +11,10 @@ public class StoreRankingDto {
 	private final Integer totalSales;
 	private final Long    currentRank;
 	private final Integer delta;
+	private final String profileUrl;
 
 	public StoreRankingDto(Long storeId, String storeName, Long departmentId, String departmentName, Integer totalSales,
-		Long currentRank, Integer delta) {
+		Long currentRank, Integer delta, String profileUrl) {
 		this.storeId = storeId;
 		this.storeName = storeName;
 		this.departmentId = departmentId;
@@ -21,5 +22,6 @@ public class StoreRankingDto {
 		this.totalSales = totalSales;
 		this.currentRank = currentRank;
 		this.delta = delta;
+		this.profileUrl = profileUrl;
 	}
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/service/impl/RankingServiceImpl.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/service/impl/RankingServiceImpl.java
@@ -45,7 +45,7 @@ public class RankingServiceImpl implements RankingService {
 		// 1) Redis에서 Top4+내주점: storeId, totalSales, currentRank, delta
 		List<RankingEntry> entries = rankingQuery.getRankings(userStoreId, 5);
 
-		// 2) DB에서 store 정보 가져오기
+		// 2) redis 에서 storeId 정보 가져오기
 		List<Long> storeIds = entries.stream()
 			.map(RankingEntry::getStoreId)
 			.toList();
@@ -67,7 +67,8 @@ public class RankingServiceImpl implements RankingService {
 					info.getDepartmentName(),
 					e.getTotalSales(),
 					e.getCurrentRank(),
-					e.getDelta()
+					e.getDelta(),
+					info.getProfileUrl()
 				);
 			})
 			.collect(Collectors.toList());

--- a/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/dto/StoreInfo.java
+++ b/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/dto/StoreInfo.java
@@ -8,11 +8,13 @@ public class StoreInfo {
 	private final String storeName;
 	private final Long departmentId;
 	private final String departmentName;
+	private final String profileUrl;
 
-	public StoreInfo(Long storeId, String storeName, Long departmentId, String departmentName) {
+	public StoreInfo(Long storeId, String storeName, Long departmentId, String departmentName, String profileUrl) {
 		this.storeId = storeId;
 		this.storeName = storeName;
 		this.departmentId = departmentId;
 		this.departmentName = departmentName;
+		this.profileUrl = profileUrl;
 	}
 }

--- a/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepositoryImpl.java
+++ b/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepositoryImpl.java
@@ -25,7 +25,6 @@ import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.QStore;
 import com.nowait.domaincorerdb.store.entity.QStoreImage;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Expression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.extern.slf4j.Slf4j;
@@ -299,7 +298,7 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 	@Override
 	public List<StoreInfo> findStoreInfoByIds(List<Long> storeIds) {
 		List<Tuple> tuples = queryFactory
-			.select(s.storeId, s.name, store.departmentId, d.name, si.imageUrl.coalesce(""))
+			.select(s.storeId, s.name, s.departmentId, d.name, si.imageUrl.coalesce(""))
 			.from(s)
 			.join(d).on(s.departmentId.eq(d.id))
 			.leftJoin(si).on(s.storeId.eq(si.store.storeId).and(si.imageType.eq(ImageType.PROFILE)))

--- a/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepositoryImpl.java
+++ b/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepositoryImpl.java
@@ -21,11 +21,17 @@ import com.nowait.domainadminrdb.statistic.dto.StoreSales;
 import com.nowait.domainadminrdb.statistic.dto.TopSalesStoresDetail;
 import com.nowait.domaincorerdb.department.entity.QDepartment;
 import com.nowait.domaincorerdb.order.entity.QUserOrder;
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.QStore;
+import com.nowait.domaincorerdb.store.entity.QStoreImage;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Repository
+@Slf4j
 public class StatisticCustomRepositoryImpl implements StatisticCustomRepository {
 
 	private final JPAQueryFactory queryFactory;
@@ -35,8 +41,9 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 	}
 
 	private static final QUserOrder u = QUserOrder.userOrder;
-	private static final QStore s = store;
+	private static final QStore s = QStore.store;
 	private static final QDepartment d = QDepartment.department;
+	private static final QStoreImage si = QStoreImage.storeImage;
 
 	@Override
 	public OrderSalesSumDetail findSalesSumByStoreId(Long storeId) {
@@ -262,8 +269,6 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 		return departmentNameMap;
 	}
 
-
-
 	// redis 사용하는 부분
 	@Override
 	public List<StoreSales> findTotalSales() {
@@ -294,18 +299,20 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 	@Override
 	public List<StoreInfo> findStoreInfoByIds(List<Long> storeIds) {
 		List<Tuple> tuples = queryFactory
-			.select(s.storeId, s.name, store.departmentId, d.name)
-			.from(store)
-			.join(d).on(store.departmentId.eq(d.id))
-			.where(store.storeId.in(storeIds))
+			.select(s.storeId, s.name, store.departmentId, d.name, si.imageUrl.coalesce(""))
+			.from(s)
+			.join(d).on(s.departmentId.eq(d.id))
+			.leftJoin(si).on(s.storeId.eq(si.store.storeId).and(si.imageType.eq(ImageType.PROFILE)))
+			.where(s.storeId.in(storeIds))
 			.fetch();
 
 		return tuples.stream()
 			.map(t -> new StoreInfo(
-				t.get(store.storeId),
-				t.get(store.name),
-				t.get(store.departmentId),
-				t.get(d.name)
+				t.get(s.storeId),
+				t.get(s.name),
+				t.get(s.departmentId),
+				t.get(d.name),
+				t.get(si.imageUrl.coalesce(""))
 			))
 			.collect(Collectors.toList());
 	}


### PR DESCRIPTION
## 작업 요약
- StoreRankingDto에 profileUrl 필드 추가
- findStoreInfoByIds 쿼리 수정
- StoreInfo profileUrl 필드 추가
## Issue Link
#108 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 랭킹 및 정보 조회 시 매장 프로필 이미지 URL이 함께 제공됩니다.

* **버그 수정**
  * 일부 매장 정보 조회 시 프로필 이미지가 없을 경우 빈 문자열로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->