### PR TITLE
feat(Reservation): 대기열 조회 및 취소

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/controller/ReservationController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/controller/ReservationController.java
@@ -3,6 +3,8 @@ package com.nowait.applicationuser.reservation.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,6 +62,39 @@ public class ReservationController {
 			.body(
 				ApiUtils.success(
 					response
+				)
+			);
+	}
+
+	@GetMapping("/get/queue/redis/{storeId}")
+	@Operation(summary = "본인 대기열 조회", description = "특정 주점에 대한 본인 대기열 조회")
+	@ApiResponse(responseCode = "200", description = "본인 대기열 조회")
+	public ResponseEntity<?> getQueue(
+		@PathVariable Long storeId,
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User
+	) {
+		WaitingResponseDto response = reservationService.myWaitingInfo(storeId,customOAuth2User);
+		return ResponseEntity
+			.ok()
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
+	}
+
+	@DeleteMapping("/delete/queue/redis/{storeId}")
+	@Operation(summary = "내 대기열 취소", description = "특정 주점에 대한 대기열 취소")
+	@ApiResponse(responseCode = "200", description = "대기열 취소")
+	public ResponseEntity<?> deleteQueue(
+		@PathVariable Long storeId,
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User
+	) {
+		return ResponseEntity
+			.ok()
+			.body(
+				ApiUtils.success(
+					reservationService.cancelWaiting(storeId,customOAuth2User)
 				)
 			);
 	}

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingRedisRepository.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingRedisRepository.java
@@ -27,7 +27,7 @@ public class WaitingRedisRepository {
 	public Integer getPartySize(Long storeId, String userId) {
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
 		Object value = redisTemplate.opsForHash().get(partyKey, userId);
-		return value == null ? null : Integer.valueOf(value.toString());
+		return Integer.valueOf(value.toString());
 	}
 
 	public Long getRank(Long storeId, String userId) {

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
@@ -11,6 +11,7 @@ import com.nowait.applicationuser.reservation.dto.ReservationCreateResponseDto;
 import com.nowait.applicationuser.reservation.dto.WaitingResponseDto;
 import com.nowait.applicationuser.reservation.repository.WaitingRedisRepository;
 import com.nowait.common.enums.ReservationStatus;
+import com.nowait.common.enums.Role;
 import com.nowait.domaincorerdb.reservation.entity.Reservation;
 import com.nowait.domaincorerdb.reservation.exception.DuplicateReservationException;
 import com.nowait.domaincorerdb.reservation.repository.ReservationRepository;
@@ -42,6 +43,12 @@ public class ReservationService {
 			.orElseThrow(StoreNotFoundException::new);
 		if (Boolean.FALSE.equals(store.getIsActive()))
 			throw new StoreWaitingDisabledException();
+		// User Role 검증 추가
+		User user = userRepository.findById(customOAuth2User.getUserId())
+			.orElseThrow(UserNotFoundException::new);
+		if (user.getRole() == Role.MANAGER) {
+			throw new IllegalArgumentException("Manager cannot register waiting");
+		}
 
 		String userId = customOAuth2User.getUserId().toString();
 		long timestamp = System.currentTimeMillis();
@@ -59,9 +66,10 @@ public class ReservationService {
 			.build();
 	}
 
-	public WaitingResponseDto myWaitingInfo(Long storeId, String userId) {
+	public WaitingResponseDto myWaitingInfo(Long storeId, CustomOAuth2User customOAuth2User) {
+		String userId = customOAuth2User.getUserId().toString();
 		// 입력 검증 추가
-		if (storeId == null || userId == null || userId.trim().isEmpty()) {
+		if (storeId == null || userId.trim().isEmpty()) {
 		throw new IllegalArgumentException("Invalid storeId or userId");
 		}
 		Long rank = waitingRedisRepository.getRank(storeId, userId);
@@ -72,8 +80,9 @@ public class ReservationService {
 			.build();
 	}
 
-	public boolean cancelWaiting(Long storeId, String userId) {
-		if (storeId == null || userId == null || userId.trim().isEmpty()) {
+	public boolean cancelWaiting(Long storeId, CustomOAuth2User customOAuth2User) {
+		String userId = customOAuth2User.getUserId().toString();
+		if (storeId == null || userId.trim().isEmpty()) {
 			throw new IllegalArgumentException("Invalid storeId or userId");
 		}
 		// 대기열에서 제거 및 결과 반환


### PR DESCRIPTION
## 작업 요약
- 대기열 조회 및 취소 api 추가
## Issue Link
#121 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 특정 매장의 대기열 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  * 사용자가 특정 매장의 대기열을 취소할 수 있는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 대기 등록 시 매장 관리자 계정은 대기 등록이 불가능하도록 역할 검증이 추가되었습니다.

* **리팩터**
  * 사용자 인증 정보를 일관성 있게 처리하도록 내부 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->