### PR TITLE
feat(Reservation): 관리자 예약 대기열 호출

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nowait.applicationadmin.reservation.dto.CallGetResponseDto;
+import com.nowait.applicationadmin.reservation.dto.CallingWaitingResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusSummaryDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusUpdateRequestDto;
 import com.nowait.applicationadmin.reservation.service.ReservationService;
@@ -59,6 +61,22 @@ public class ReservationController {
 					response
 				)
 			);
+	}
+
+	@PatchMapping("/admin/calling/redis/{storeId}")
+	@Operation(summary = "예약팀 호출", description = "특정 예약에 대한 호출 진행(호출하는 순간 10분 타임어택)")
+	@ApiResponse(responseCode = "200", description = "예약팀 상태 변경 :  WAITING -> CALLING")
+	public ResponseEntity<?> callWaiting(@PathVariable Long storeId,
+		@RequestParam String userId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		CallingWaitingResponseDto response = reservationService.callWaiting(storeId, userId, memberDetails);
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(
+				ApiUtils.success(
+					response
+				)
+	);
 	}
 
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/CallingWaitingResponseDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/CallingWaitingResponseDto.java
@@ -1,0 +1,35 @@
+package com.nowait.applicationadmin.reservation.dto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자 호출(호출 상태 변경) 응답 DTO")
+public class CallingWaitingResponseDto {
+	@Schema(description = "매장 ID", example = "7")
+	private Long storeId;
+
+	@Schema(description = "유저 ID", example = "123")
+	private String userId;
+
+	@Schema(description = "대기 상태", example = "CALLING")
+	private String status;
+
+	@Schema(description = "호출 시각", example = "2025-07-21T17:01:00")
+	private LocalDateTime calledAt;
+
+	@Schema(description = "대기 순번", example = "3")
+	private Integer rank;
+
+	@Schema(description = "파티 인원", example = "4")
+	private Integer partySize;
+
+
+}

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
@@ -1,5 +1,7 @@
 package com.nowait.applicationadmin.reservation.repository;
 
+import java.time.Duration;
+
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -17,6 +19,27 @@ public class WaitingRedisRepository {
 		String key = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		Long count = redisTemplate.opsForZSet().zCard(key);
 		return count == null ? 0 : count;
+	}
+
+	// 상태값 저장 및 변경
+	public void setWaitingStatus(Long storeId, String userId, String status) {
+		String queueKey = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
+		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
+		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
+		redisTemplate.opsForHash().put(statusKey, userId, status);
+		// WAITING -> CALLING 으로 변경 시 TTL 12h에서 10m로 변경
+		if (status.equals("CALLING")) {
+			redisTemplate.expire(queueKey, Duration.ofMinutes(10));
+			redisTemplate.expire(partyKey, Duration.ofMinutes(10));
+			redisTemplate.expire(statusKey, Duration.ofMinutes(10));
+		}
+	}
+
+	// 상태값 조회
+	public String getWaitingStatus(Long storeId, String userId) {
+		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
+		Object value = redisTemplate.opsForHash().get(statusKey, userId);
+		return value == null ? null : value.toString();
 	}
 }
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
@@ -28,7 +28,7 @@ public class WaitingRedisRepository {
 		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
 		redisTemplate.opsForHash().put(statusKey, userId, status);
 		// WAITING -> CALLING 으로 변경 시 TTL 12h에서 10m로 변경
-		if (status.equals("CALLING")) {
+		if ("CALLING".equals(status)) {
 			redisTemplate.expire(queueKey, Duration.ofMinutes(10));
 			redisTemplate.expire(partyKey, Duration.ofMinutes(10));
 			redisTemplate.expire(statusKey, Duration.ofMinutes(10));

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -77,14 +77,12 @@ public class ReservationService {
 			reservation.updateStatus(requestDto.getStatus());
 		return CallGetResponseDto.fromEntity(reservation);
 	}
-	@Transactional
 	public CallingWaitingResponseDto callWaiting(Long storeId, String userId, MemberDetails memberDetails) {
 		User user =  userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
 		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(storeId)) {
 			throw new ReservationViewUnauthorizedException();
 		}
 		String status = waitingRedisRepository.getWaitingStatus(storeId, userId);
-		System.out.println(status);
 		if (!"WAITING".equals(status)) {
 			throw new IllegalStateException("이미 호출되었거나 없는 예약입니다.");
 		}

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.nowait.applicationadmin.reservation.service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,9 +8,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nowait.applicationadmin.reservation.dto.CallGetResponseDto;
+import com.nowait.applicationadmin.reservation.dto.CallingWaitingResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationGetResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusSummaryDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusUpdateRequestDto;
+import com.nowait.applicationadmin.reservation.repository.WaitingRedisRepository;
 import com.nowait.common.enums.ReservationStatus;
 import com.nowait.common.enums.Role;
 import com.nowait.domaincorerdb.order.exception.OrderUpdateUnauthorizedException;
@@ -31,6 +34,7 @@ public class ReservationService {
 
 	private final ReservationRepository reservationRepository;
 	private final UserRepository userRepository;
+	private final WaitingRedisRepository waitingRedisRepository;
 
 	@Transactional(readOnly = true)
 	public ReservationStatusSummaryDto getReservationListByStoreId(Long storeId, MemberDetails memberDetails) {
@@ -73,7 +77,27 @@ public class ReservationService {
 			reservation.updateStatus(requestDto.getStatus());
 		return CallGetResponseDto.fromEntity(reservation);
 	}
-
+	@Transactional
+	public CallingWaitingResponseDto callWaiting(Long storeId, String userId, MemberDetails memberDetails) {
+		User user =  userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
+		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(storeId)) {
+			throw new ReservationViewUnauthorizedException();
+		}
+		String status = waitingRedisRepository.getWaitingStatus(storeId, userId);
+		System.out.println(status);
+		if (!"WAITING".equals(status)) {
+			throw new IllegalStateException("이미 호출되었거나 없는 예약입니다.");
+		}
+		waitingRedisRepository.setWaitingStatus(storeId, userId, "CALLING");
+		LocalDateTime calledAt = LocalDateTime.now();
+		return CallingWaitingResponseDto.builder()
+			.storeId(storeId)
+			.userId(userId)
+			.status("CALLING")
+			.calledAt(calledAt)
+			.build();
+	}
+	//TODO CALLING -> 입장완료 처리 로직 구현 필요(redis에서 삭제 후 RDB에 저장하는게 나을지??)
 
 }
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
@@ -14,13 +14,15 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class WaitingRedisRepository {
+public class WaitingUserRedisRepository {
 	private final StringRedisTemplate redisTemplate;
 
 	// 중복 등록 방지: 이미 있으면 추가X
+	// 특정 주점에 대한 예약 등록
 	public boolean addToWaitingQueue(Long storeId, String userId, Integer partySize, long timestamp) {
 		String queueKey = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
+		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
 
 		Boolean added = redisTemplate.opsForZSet().addIfAbsent(queueKey, userId, timestamp);
 		if (Boolean.TRUE.equals(added)) {
@@ -28,26 +30,22 @@ public class WaitingRedisRepository {
 			// TTL 12시간(43200초) 설정
 			redisTemplate.expire(queueKey, Duration.ofHours(12));
 			redisTemplate.expire(partyKey, Duration.ofHours(12));
+			redisTemplate.expire(statusKey, Duration.ofHours(12));
 		}
 		return Boolean.TRUE.equals(added);
 	}
-
+	// 예약한 사람이 등록한 동반인원(partySize) 조회
 	public Integer getPartySize(Long storeId, String userId) {
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
 		Object value = redisTemplate.opsForHash().get(partyKey, userId);
 		return Integer.valueOf(value.toString());
 	}
-
+	// 예약자 대기순위 조회
 	public Long getRank(Long storeId, String userId) {
 		String key = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		return redisTemplate.opsForZSet().rank(key, userId);
 	}
-
-	public Long getWaitingCount(Long storeId) {
-		String key = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
-		return redisTemplate.opsForZSet().zCard(key);
-	}
-
+	// 예약 취소
 	public boolean removeWaiting(Long storeId, String userId) {
 		String key = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
@@ -55,14 +53,14 @@ public class WaitingRedisRepository {
 		redisTemplate.opsForHash().delete(partyKey, userId);
 		return true;
 	}
-
+	// 예약 등록 시간
 	public Long getWaitingTimestamp(Long storeId, String userId) {
 		String key = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		Double score = redisTemplate.opsForZSet().score(key, userId);
 		return score == null ? null : score.longValue();
 	}
 
-	// 사용자	대기중인 매장 목록
+	// 사용자가 대기중인 전체 매장 목록 조회
 	public List<Long> getUserWaitingStoreIds(String userId) {
 		// key pattern으로 모든 매장 대기열 조회 (keys: waiting:*)
 		Set<String> keys = redisTemplate.keys(RedisKeyUtils.buildWaitingKeyPrefix() + "*");
@@ -83,7 +81,12 @@ public class WaitingRedisRepository {
 		}
 		return result;
 	}
-
+	// 상태값 조회
+	public String getWaitingStatus(Long storeId, String userId) {
+		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
+		Object value = redisTemplate.opsForHash().get(statusKey, userId);
+		return value == null ? null : value.toString();
+	}
 
 }
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
@@ -27,6 +27,7 @@ public class WaitingUserRedisRepository {
 		Boolean added = redisTemplate.opsForZSet().addIfAbsent(queueKey, userId, timestamp);
 		if (Boolean.TRUE.equals(added)) {
 			redisTemplate.opsForHash().put(partyKey, userId, partySize.toString());
+			redisTemplate.opsForHash().put(statusKey, userId, "WAITING");
 			// TTL 12시간(43200초) 설정
 			redisTemplate.expire(queueKey, Duration.ofHours(12));
 			redisTemplate.expire(partyKey, Duration.ofHours(12));
@@ -49,8 +50,10 @@ public class WaitingUserRedisRepository {
 	public boolean removeWaiting(Long storeId, String userId) {
 		String key = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
+		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
 		redisTemplate.opsForZSet().remove(key, userId);
 		redisTemplate.opsForHash().delete(partyKey, userId);
+		redisTemplate.opsForHash().delete(statusKey, userId);
 		return true;
 	}
 	// 예약 등록 시간

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
@@ -17,7 +17,7 @@ import com.nowait.applicationuser.reservation.dto.MyWaitingQueueDto;
 import com.nowait.applicationuser.reservation.dto.ReservationCreateRequestDto;
 import com.nowait.applicationuser.reservation.dto.ReservationCreateResponseDto;
 import com.nowait.applicationuser.reservation.dto.WaitingResponseDto;
-import com.nowait.applicationuser.reservation.repository.WaitingRedisRepository;
+import com.nowait.applicationuser.reservation.repository.WaitingUserRedisRepository;
 import com.nowait.common.enums.ReservationStatus;
 import com.nowait.common.enums.Role;
 import com.nowait.domaincorerdb.department.entity.Department;
@@ -43,7 +43,7 @@ public class ReservationService {
 	private final ReservationRepository reservationRepository;
 	private final StoreRepository storeRepository;
 	private final UserRepository userRepository;
-	private final WaitingRedisRepository waitingRedisRepository;
+	private final WaitingUserRedisRepository waitingUserRedisRepository;
 	private final DepartmentRepository departmentRepository;
 
 	public WaitingResponseDto registerWaiting(
@@ -65,12 +65,12 @@ public class ReservationService {
 		long timestamp = System.currentTimeMillis();
 
 		// 예약 신청 유저 큐(queue)에 추가
-		boolean added = waitingRedisRepository.addToWaitingQueue(storeId, userId, requestDto.getPartySize(), timestamp);
+		boolean added = waitingUserRedisRepository.addToWaitingQueue(storeId, userId, requestDto.getPartySize(), timestamp);
 		if (!added) {
 			throw new IllegalArgumentException("Failed to add to waiting queue");
 		}
 		// 신규 등록/기존 등록 관계없이 내 순번, 전체 인원 반환
-		Long rank = waitingRedisRepository.getRank(storeId, userId);
+		Long rank = waitingUserRedisRepository.getRank(storeId, userId);
 		return WaitingResponseDto.builder()
 			.rank(rank == null ? -1 : rank.intValue() + 1)
 			.partySize(requestDto.getPartySize() == null ? 0 : requestDto.getPartySize())
@@ -83,8 +83,8 @@ public class ReservationService {
 		if (storeId == null || userId.trim().isEmpty()) {
 		throw new IllegalArgumentException("Invalid storeId or userId");
 		}
-		Long rank = waitingRedisRepository.getRank(storeId, userId);
-		Integer partySize = waitingRedisRepository.getPartySize(storeId, userId);
+		Long rank = waitingUserRedisRepository.getRank(storeId, userId);
+		Integer partySize = waitingUserRedisRepository.getPartySize(storeId, userId);
 		return WaitingResponseDto.builder()
 			.rank(rank == null ? -1 : rank.intValue() + 1)
 			.partySize(partySize == null ? 0 : partySize)
@@ -97,7 +97,7 @@ public class ReservationService {
 			throw new IllegalArgumentException("Invalid storeId or userId");
 		}
 		// 대기열에서 제거 및 결과 반환
-		boolean removed = waitingRedisRepository.removeWaiting(storeId, userId);
+		boolean removed = waitingUserRedisRepository.removeWaiting(storeId, userId);
 		if (!removed) {
 			throw new IllegalArgumentException("Waiting not found");
 		}
@@ -106,7 +106,7 @@ public class ReservationService {
 	//TODO 성능 개선 필요
 	public List<MyWaitingQueueDto> getAllMyWaitings(CustomOAuth2User customOAuth2User) {
 		String userId = customOAuth2User.getUserId().toString();
-		List<Long> userWaitingStoreIds = waitingRedisRepository.getUserWaitingStoreIds(userId);
+		List<Long> userWaitingStoreIds = waitingUserRedisRepository.getUserWaitingStoreIds(userId);
 
 		List<MyWaitingQueueDto> result = new ArrayList<>();
 		if (!userWaitingStoreIds.isEmpty()) {
@@ -125,9 +125,9 @@ public class ReservationService {
 				Store store = storeMap.get(storeId);
 				if (store == null) continue;
 
-				Long rank = waitingRedisRepository.getRank(storeId, userId);
-				Integer partySize = waitingRedisRepository.getPartySize(storeId, userId);
-				Long timestamp = waitingRedisRepository.getWaitingTimestamp(storeId, userId);
+				Long rank = waitingUserRedisRepository.getRank(storeId, userId);
+				Integer partySize = waitingUserRedisRepository.getPartySize(storeId, userId);
+				Long timestamp = waitingUserRedisRepository.getWaitingTimestamp(storeId, userId);
 
 				LocalDateTime registeredAt = timestamp != null
 					? LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.of("Asia/Seoul"))
@@ -140,7 +140,7 @@ public class ReservationService {
 					.rank(rank != null ? rank.intValue() + 1 : 0)
 					.teamsAhead(rank != null ? rank.intValue() : 0)
 					.partySize(partySize != null ? partySize : 0)
-					.status("WAITING") // 필요시 redis에 상태값이 있으면 조회해서 세팅
+					.status(waitingUserRedisRepository.getWaitingStatus(storeId, userId)) // 필요시 redis에 상태값이 있으면 조회해서 세팅
 					.registeredAt(registeredAt)
 					.location(store.getLocation())
 					.profileImageUrl(customOAuth2User.getUser().getProfileImage())

--- a/nowait-domain/domain-redis/src/main/java/com/nowait/domaincoreredis/common/util/RedisKeyUtils.java
+++ b/nowait-domain/domain-redis/src/main/java/com/nowait/domaincoreredis/common/util/RedisKeyUtils.java
@@ -16,6 +16,7 @@ public class RedisKeyUtils {
 	// Waiting keys
 	private static final String WAITING_KEY_PREFIX = "waiting:";
 	private static final String WAITING_PARTYSIZE_KEY_PREFIX = "waiting:party:";
+	private static final String WAITING_STATUS_KEY_PREFIX = "waiting:status:";
 
 
 	private RedisKeyUtils() {
@@ -40,4 +41,5 @@ public class RedisKeyUtils {
 
 	public static String buildWaitingKeyPrefix() { return WAITING_KEY_PREFIX; }
 	public static String buildWaitingPartySizeKeyPrefix() { return WAITING_PARTYSIZE_KEY_PREFIX; }
+	public static String buildWaitingStatusKeyPrefix() { return WAITING_STATUS_KEY_PREFIX; }
 }


### PR DESCRIPTION
## 작업 요약
- redis에 예약 상태 key 추가
- 특정 userId 호출 로직 구현
- 예약 상태 CALLING으로 변경 시, TTL 10분으로 변경
## Issue Link

## 문제점 및 어려움
- 입장완료 시 redis에서 삭제할지, 냅둘지?(어차피 TTL 10분이기 때문)
## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 대기 중인 사용자를 10분간 호출할 수 있는 PATCH 엔드포인트가 추가되었습니다.
  * 관리자의 호출 결과를 포함하는 응답 구조가 추가되었습니다.

* **버그 수정**
  * 사용자 대기 상태 조회 및 관리 기능이 개선되었습니다.

* **리팩터**
  * 사용자 대기 관련 Redis 저장소 클래스 및 서비스 명칭이 변경되고, 관련 메서드가 일관성 있게 통합되었습니다.

* **문서화**
  * API 응답에 대한 예시 및 설명이 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->