### PR TITLE
feat(Order): 주문 조회 N + 1 문제 해결

### DIFF
--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/order/repository/OrderRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/order/repository/OrderRepository.java
@@ -3,6 +3,7 @@ package com.nowait.domaincorerdb.order.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,6 @@ public interface OrderRepository extends JpaRepository<UserOrder, Long> {
 
 	List<UserOrder> findByStore_StoreIdAndTableIdAndSessionId(Long storeId, Long tableId, String sessionId);
 
+	@EntityGraph(attributePaths = {"orderItems", "orderItems.menu"})
 	List<UserOrder> findAllByStore_StoreId(Long storeId);
 }


### PR DESCRIPTION
## 작업 요약
- 주문 목록 조회 시 발생하는 N + 1 문제 해결 
- EntityGraph 적용
## Issue Link
#132 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매장별 주문 내역 조회 시, 주문 항목과 해당 메뉴 정보가 함께 불러와져 더 빠르고 정확한 데이터 확인이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->