### PR TITLE
refactor(rank): 매출 데이터 없는 경우 redis 초기화 로직 추가

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/scheduler/RankingRefreshScheduler.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/scheduler/RankingRefreshScheduler.java
@@ -60,6 +60,10 @@ public class RankingRefreshScheduler {
 
 		if (salesList.isEmpty()) {
 			log.warn("매출 데이터가 없습니다. 다음 스냅샷 키를 초기화합니다.");
+			redis.delete(currentKey);
+			redis.delete(previousKey);
+			redis.delete(nextKey);
+
 			return;
 		}
 


### PR DESCRIPTION
## 작업 요약
- 매출 데이터 없는 경우 redis 초기화 로직 추가
## Issue Link
#137 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매출 데이터가 없을 때 랭킹 스냅샷 관련 캐시가 모두 삭제되어, 이전 데이터가 남아있지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->