### PR TITLE
Refactor: 날짜별 매출 조회 기능 구현 및 주점 랭킹 내 주문 건수 필드 추가

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/service/OrderService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.nowait.applicationadmin.order.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -81,7 +82,7 @@ public class OrderService {
 	}
 
 	@Transactional(readOnly = true)
-	public OrderSalesSumDetail getSaleSumByStoreId(MemberDetails memberDetails) {
+	public OrderSalesSumDetail getSaleSumByStoreId(MemberDetails memberDetails, LocalDate date) {
 		User user = userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
 		Long storeId = user.getStoreId();
 
@@ -89,7 +90,7 @@ public class OrderService {
 			throw new OrderViewUnauthorizedException();
 		}
 
-		return statisticCustomRepository.findSalesSumByStoreId(storeId);
+		return statisticCustomRepository.findSalesSumByStoreId(storeId, date);
 	}
 
 	@Transactional(readOnly = true)

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/controller/StatisticsController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/controller/StatisticsController.java
@@ -1,12 +1,15 @@
 package com.nowait.applicationadmin.statistic.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nowait.applicationadmin.order.service.OrderService;
@@ -34,10 +37,18 @@ public class StatisticsController {
 	private final PopularMenuRedisService popularMenuRedisService;
 
 	@GetMapping("/sales")
-	@Operation(summary = "오늘의 매출 조회", description = "오늘의 매출을 조회합니다.")
+	@Operation(summary = "지정일 매출 조회", description = "날짜(date) 파라미터로 매출을 조회합니다. 포맷: yyyy-MM-dd")
 	@ApiResponse(responseCode = "200", description = "오늘의 매출 조회 성공")
-	public ResponseEntity<?> getTodaySales(@AuthenticationPrincipal MemberDetails memberDetails) {
-		OrderSalesSumDetail sales = orderService.getSaleSumByStoreId(memberDetails);
+	public ResponseEntity<?> getTodaySales(
+		@AuthenticationPrincipal MemberDetails memberDetails,
+		@RequestParam(value = "date", required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+		LocalDate targetDate = (date != null ? date : LocalDate.now());
+		OrderSalesSumDetail sales = orderService.getSaleSumByStoreId(memberDetails, targetDate);
+
+		if (sales.isAllZero()) {
+			return ResponseEntity.ok(ApiUtils.success("해당일 매출 데이터가 없습니다."));
+		}
 
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/dto/StoreRankingDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/dto/StoreRankingDto.java
@@ -9,17 +9,19 @@ public class StoreRankingDto {
 	private final Long departmentId;
 	private final String departmentName;
 	private final Integer totalSales;
+	private final Integer orderCount;
 	private final Long currentRank;
 	private final Integer delta;
 	private final String profileUrl;
 
 	public StoreRankingDto(Long storeId, String storeName, Long departmentId, String departmentName, Integer totalSales,
-		Long currentRank, Integer delta, String profileUrl) {
+		Integer orderCount, Long currentRank, Integer delta, String profileUrl) {
 		this.storeId = storeId;
 		this.storeName = storeName;
 		this.departmentId = departmentId;
 		this.departmentName = departmentName;
 		this.totalSales = totalSales;
+		this.orderCount = orderCount;
 		this.currentRank = currentRank;
 		this.delta = delta;
 		this.profileUrl = profileUrl;

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/scheduler/RankingRefreshScheduler.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/scheduler/RankingRefreshScheduler.java
@@ -35,7 +35,7 @@ public class RankingRefreshScheduler {
 		refresh();
 	}
 
-	@Scheduled(cron = "*/30 * * * * *") // 매 5분마다 실행
+	@Scheduled(cron = "0 */5 * * * *") // 매 5분마다 실행
 	public void refresh() {
 		log.info("RankingRefreshScheduler.refresh() called at {}", LocalDateTime.now());
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/service/impl/RankingServiceImpl.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/statistic/service/impl/RankingServiceImpl.java
@@ -31,7 +31,6 @@ public class RankingServiceImpl implements RankingService {
 	private final UserRepository userRepository;
 	private final RankingQueryService rankingQuery;
 
-
 	@Override
 	@Transactional(readOnly = true)
 	public List<StoreRankingDto> getStatisticsRankings(MemberDetails memberDetails) {
@@ -45,27 +44,32 @@ public class RankingServiceImpl implements RankingService {
 		// 1) Redis에서 Top4+내주점: storeId, totalSales, currentRank, delta
 		List<RankingEntry> entries = rankingQuery.getRankings(userStoreId, 5);
 
-		// 2) redis 에서 storeId 정보 가져오기
+		// 2) 주문 건수 조회
 		List<Long> storeIds = entries.stream()
 			.map(RankingEntry::getStoreId)
 			.toList();
 
+		Map<Long, Integer> orderCountMap = statisticCustomRepository.findOrderCountByStoreIds(storeIds);
+
+		// 3) redis 에서 storeId 정보 가져오기
 		List<StoreInfo> infos = statisticCustomRepository.findStoreInfoByIds(storeIds);
 
 		// StoreInfo를 storeId로 매핑
 		Map<Long, StoreInfo> infoMap = infos.stream()
 			.collect(Collectors.toMap(StoreInfo::getStoreId, Function.identity()));
 
-		// 3) 매핑 → 최종 DTO
+		// 4) 매핑 → 최종 DTO
 		return entries.stream()
 			.map(e -> {
 				StoreInfo info = infoMap.get(e.getStoreId());
+				Integer orderCount = orderCountMap.getOrDefault(e.getStoreId(), 0);
 				return new StoreRankingDto(
 					e.getStoreId(),
 					info.getStoreName(),
 					info.getDepartmentId(),
 					info.getDepartmentName(),
 					e.getTotalSales(),
+					orderCount,
 					e.getCurrentRank(),
 					e.getDelta(),
 					info.getProfileUrl()

--- a/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/dto/OrderSalesSumDetail.java
+++ b/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/dto/OrderSalesSumDetail.java
@@ -1,5 +1,7 @@
 package com.nowait.domainadminrdb.statistic.dto;
 
+import java.time.LocalDate;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,12 +12,18 @@ public class OrderSalesSumDetail {
 	private Integer todaySalesSum;
 	private Integer yesterdaySalesSum;
 	private Integer cumulativeSalesBeforeYesterday;
+	private LocalDate date;
 
 	public OrderSalesSumDetail(Long storeId, Integer todaySalesSum, Integer yesterdaySalesSum,
-		Integer cumulativeSalesBeforeYesterday) {
+		Integer cumulativeSalesBeforeYesterday, LocalDate date) {
 		this.storeId = storeId;
 		this.todaySalesSum = todaySalesSum;
 		this.yesterdaySalesSum = yesterdaySalesSum;
 		this.cumulativeSalesBeforeYesterday = cumulativeSalesBeforeYesterday;
+		this.date = date;
+	}
+
+	public boolean isAllZero() {
+		return todaySalesSum == 0 && yesterdaySalesSum == 0 && cumulativeSalesBeforeYesterday == 0;
 	}
 }

--- a/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepository.java
+++ b/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepository.java
@@ -1,6 +1,8 @@
 package com.nowait.domainadminrdb.statistic.repository;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 import com.nowait.domainadminrdb.statistic.dto.OrderSalesSumDetail;
 import com.nowait.domainadminrdb.statistic.dto.StoreInfo;
@@ -11,9 +13,11 @@ import com.nowait.domainadminrdb.statistic.dto.TopSalesStoresDetail;
 
 public interface StatisticCustomRepository {
 
-	OrderSalesSumDetail findSalesSumByStoreId(Long storeId);
+	OrderSalesSumDetail findSalesSumByStoreId(Long storeId, LocalDate date);
 
 	List<TopSalesStoresDetail> getTop4PlusMine(Long storeId);
+
+	Map<Long, Integer> findOrderCountByStoreIds(List<Long> storeIds);
 
 
 	// redis 사용하는 부분

--- a/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepositoryImpl.java
+++ b/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepositoryImpl.java
@@ -45,25 +45,19 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 	private static final QStoreImage si = QStoreImage.storeImage;
 
 	@Override
-	public OrderSalesSumDetail findSalesSumByStoreId(Long storeId) {
-		// 1. 날짜 기준 설정 (시작은 자정, 끝은 다음 날 자정)
-		LocalDate today = LocalDate.now();
-		LocalDate yesterday = today.minusDays(1);
+	public OrderSalesSumDetail findSalesSumByStoreId(Long storeId, LocalDate date) {
+		// 1) 시작, 끝 날짜 설정
+		LocalDateTime start = date.atStartOfDay(); // 해당 날짜의 자정
+		LocalDateTime end = date.plusDays(1).atStartOfDay();
 
-		LocalDateTime todayStart = today.atStartOfDay();
-		LocalDateTime todayEnd = today.plusDays(1).atStartOfDay(); // 내일 00:00:00
-
-		LocalDateTime yesterdayStart = yesterday.atStartOfDay();
-		LocalDateTime yesterdayEnd = today.atStartOfDay();
-
-		// 2. 오늘 매출 합산
-		Integer todaySum = queryFactory
+		// 2) target 날짜 해당하는 매출 합산
+		Integer targetSum = queryFactory
 			.select(u.totalPrice.sum())
 			.from(u)
 			.where(
 				u.store.storeId.eq(storeId),
-				u.createdAt.goe(todayStart),
-				u.createdAt.lt(todayEnd),
+				u.createdAt.goe(start),
+				u.createdAt.lt(end),
 				u.status.eq(COOKED)
 			)
 			.fetchOne();
@@ -74,8 +68,8 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 			.from(u)
 			.where(
 				u.store.storeId.eq(storeId),
-				u.createdAt.goe(yesterdayStart),
-				u.createdAt.lt(yesterdayEnd),
+				u.createdAt.goe(start),
+				u.createdAt.lt(start.minusDays(1)),
 				u.status.eq(COOKED)
 			)
 			.fetchOne();
@@ -85,21 +79,21 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 			.from(u)
 			.where(
 				u.store.storeId.eq(storeId),
-				u.createdAt.lt(yesterdayEnd),
+				u.createdAt.lt(start),
 				u.status.eq(COOKED)
 			)
 			.fetchOne();
 
 		// null 방어 처리
-		if (todaySum == null)
-			todaySum = 0;
+		if (targetSum == null)
+			targetSum = 0;
 		if (yesterdaySum == null)
 			yesterdaySum = 0;
 		if (cumulativeSalesBeforeYesterday == null)
 			cumulativeSalesBeforeYesterday = 0;
 
 		// 4. 응답 객체 생성
-		return new OrderSalesSumDetail(storeId, todaySum, yesterdaySum, cumulativeSalesBeforeYesterday);
+		return new OrderSalesSumDetail(storeId, targetSum, yesterdaySum, cumulativeSalesBeforeYesterday, date);
 	}
 
 	@Override
@@ -146,6 +140,32 @@ public class StatisticCustomRepositoryImpl implements StatisticCustomRepository 
 			.collect(Collectors.toList());
 
 		return result;
+	}
+
+	@Override
+	public Map<Long, Integer> findOrderCountByStoreIds(List<Long> storeIds) {
+		LocalDate today = LocalDate.now();
+		LocalDateTime start = today.atStartOfDay();
+		LocalDateTime end = today.plusDays(1).atStartOfDay();
+
+		List<Tuple> rows = queryFactory
+			.select(u.store.storeId, u.count())
+			.from(u)
+			.where(
+				u.store.storeId.in(storeIds),
+				u.createdAt.goe(start),
+				u.createdAt.lt(end),
+				u.status.eq(COOKED)
+			)
+			.groupBy(u.store.storeId)
+			.fetch();
+
+		// Tuple → Map<Long,Integer>
+		return rows.stream()
+			.collect(Collectors.toMap(
+				t -> t.get(u.store.storeId),
+				t -> t.get(u.count()).intValue()
+			));
 	}
 
 	private List<Tuple> getAllStores(LocalDateTime todayStart, LocalDateTime todayEnd) {


### PR DESCRIPTION
## 작업 요약
날짜별 매출 조회 기능 구현 및 주점 랭킹 내 주문 건수 필드 추가
## Issue Link
#141 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매장별 매출 합계 조회 시 특정 날짜를 지정할 수 있는 기능이 추가되었습니다.
  * 매장 순위 정보에 주문 건수(orderCount) 항목이 추가되었습니다.

* **버그 수정**
  * 매출 데이터가 모두 0인 경우, 해당 날짜에 매출 데이터가 없음을 안내하는 메시지가 표시됩니다.

* **개선 사항**
  * 매장 순위 갱신 스케줄이 30초마다에서 5분마다로 변경되었습니다.
  * 매장별 주문 건수를 한 번에 조회하여 순위 정보에 반영합니다.

* **문서화**
  * 매출 합계 조회 API에 날짜 파라미터 및 동작 방식이 Swagger에 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->