### PR TITLE
fix(Reservation):예약 에러 수정

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nowait.applicationadmin.reservation.dto.CallingWaitingResponseDto;
+import com.nowait.applicationadmin.reservation.dto.EntryStatusResponseDto;
 import com.nowait.applicationadmin.reservation.dto.WaitingUserResponse;
 import com.nowait.applicationadmin.reservation.service.ReservationService;
 import com.nowait.common.api.ApiUtils;
@@ -51,21 +52,21 @@ public class ReservationController {
 		return ResponseEntity.ok(response);
 	}
 
-	@PatchMapping("/admin/{storeId}/call/{userId}")
-	@Operation(summary = "예약팀 호출", description = "특정 예약에 대한 호출 진행(호출하는 순간 10분 타임어택)")
-	@ApiResponse(responseCode = "200", description = "예약팀 상태 변경 :  WAITING -> CALLING")
-	public ResponseEntity<?> callWaiting(@PathVariable Long storeId,
-		@PathVariable String userId,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		CallingWaitingResponseDto response = reservationService.callWaiting(storeId, userId, memberDetails);
-		return ResponseEntity
-			.status(HttpStatus.OK)
-			.body(
-				ApiUtils.success(
-					response
-				)
-	);
-	}
+	// @PatchMapping("/admin/{storeId}/call/{userId}")
+	// @Operation(summary = "예약팀 호출", description = "특정 예약에 대한 호출 진행(호출하는 순간 10분 타임어택)")
+	// @ApiResponse(responseCode = "200", description = "예약팀 상태 변경 :  WAITING -> CALLING")
+	// public ResponseEntity<?> callWaiting(@PathVariable Long storeId,
+	// 	@PathVariable String userId,
+	// 	@AuthenticationPrincipal MemberDetails memberDetails) {
+	// 	CallingWaitingResponseDto response = reservationService.callWaiting(storeId, userId, memberDetails);
+	// 	return ResponseEntity
+	// 		.status(HttpStatus.OK)
+	// 		.body(
+	// 			ApiUtils.success(
+	// 				response
+	// 			)
+	// );
+	// }
 	@PatchMapping("/admin/update/{storeId}/{userId}/{status}")
 	@Operation(summary = "예약팀 상태 업데이트 처리", description = "특정 예약에 대한 입장 완료 처리")
 	@ApiResponse(responseCode = "200", description = "예약팀 상태 변경 :  CALLING -> CONFIRMED")
@@ -75,7 +76,7 @@ public class ReservationController {
 		@PathVariable ReservationStatus status,
 		@AuthenticationPrincipal MemberDetails memberDetails
 	) {
-		String response = reservationService.processEntryStatus(storeId, userId, memberDetails,status);
+		EntryStatusResponseDto response = reservationService.processEntryStatus(storeId, userId, memberDetails,status);
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/EntryStatusResponseDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/EntryStatusResponseDto.java
@@ -1,0 +1,37 @@
+package com.nowait.applicationadmin.reservation.dto;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+// DTO: 호출 시각(calledAt) 또는 완료 메시지(message)를 선택적으로 담습니다.
+@Getter
+@Builder
+public class EntryStatusResponseDto {
+	@Schema(description = "예약 ID", example = "1201")
+	private String id; // reservationId
+
+	@Schema(description = "유저 ID", example = "16")
+	private String userId;
+
+	@Schema(description = "파티 인원", example = "3")
+	private Integer partySize;
+
+	@Schema(description = "사용자 이름(닉네임)", example = "혜민이")
+	private String userName;
+
+	@Schema(description = "대기 등록 시각", example = "2025-07-22T16:00:00")
+	private LocalDateTime createdAt;
+
+	@Schema(description = "대기 상태", example = "CALLING")
+	private String status;
+
+	@Schema(description = "대기 순번/점수", example = "2.0")
+	private Double score;
+
+	@Schema(description = "호출 메시지", example = "호출 메시지")
+	private String message;
+}
+

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nowait.applicationadmin.reservation.dto.CallGetResponseDto;
 import com.nowait.applicationadmin.reservation.dto.CallingWaitingResponseDto;
+import com.nowait.applicationadmin.reservation.dto.EntryStatusResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationGetResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusSummaryDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusUpdateRequestDto;
@@ -25,6 +26,7 @@ import com.nowait.domaincorerdb.reservation.exception.ReservationNotFoundExcepti
 import com.nowait.domaincorerdb.reservation.exception.ReservationUpdateUnauthorizedException;
 import com.nowait.domaincorerdb.reservation.exception.ReservationViewUnauthorizedException;
 import com.nowait.domaincorerdb.reservation.repository.ReservationRepository;
+import com.nowait.domaincorerdb.store.entity.Store;
 import com.nowait.domaincorerdb.store.repository.StoreRepository;
 import com.nowait.domaincorerdb.user.entity.MemberDetails;
 import com.nowait.domaincorerdb.user.entity.User;
@@ -134,68 +136,111 @@ public class ReservationService {
 			.toList();
 	}
 
-	// 대기 객체 호출 (WAITING -> CALLING)
-	@Transactional
-	public CallingWaitingResponseDto callWaiting(Long storeId, String userId, MemberDetails memberDetails) {
-		User user =  userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
-		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(storeId)) {
-			throw new ReservationViewUnauthorizedException();
-		}
-		String status = waitingRedisRepository.getWaitingStatus(storeId, userId);
-		if (!"WAITING".equals(status)) {
-			throw new IllegalStateException("이미 호출되었거나 없는 예약입니다.");
-		}
-		Integer partySize = waitingRedisRepository.getWaitingPartySize(storeId, userId);
-		waitingRedisRepository.setWaitingStatus(storeId, userId, "CALLING");
-		// [2] DB에 상태 영구 저장 (없으면 생성, 있으면 상태만 변경)
-		Reservation reservation = reservationRepository.findByStore_StoreIdAndUserId(storeId, Long.valueOf(userId))
-			.orElse(
-				Reservation.builder()
-					.store(storeRepository.getReferenceById(storeId))
-					.user(userRepository.findById(Long.valueOf(userId)).get())
-					.requestedAt(LocalDateTime.now())
-					.partySize(partySize)
-					.build()
-			);
-		reservation.updateStatus(ReservationStatus.CALLING); // setter 대신 빌더로 새 객체 or withStatus 패턴 추천
-		reservationRepository.save(reservation);
-		return CallingWaitingResponseDto.builder()
-			.storeId(storeId)
-			.userId(userId)
-			.status(reservation.getStatus().name())
-			.calledAt(reservation.getRequestedAt())
-			.build();
-	}
-	// 대기 객체 상태 변경
-	@Transactional
-	public String processEntryStatus(Long storeId, String userId, MemberDetails memberDetails, ReservationStatus status) {
-		// (권한 체크 필요시 여기에 추가)
-		User user = userRepository.findById(memberDetails.getId())
-			.orElseThrow(UserNotFoundException::new);
-		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(storeId)) {
-			throw new ReservationViewUnauthorizedException();
-		}
-		// 1. DB status 업데이트
-		LocalDate today = LocalDate.now();
-		LocalDateTime startOfDay = today.atStartOfDay();
-		LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
-		Reservation reservation = reservationRepository
-			.findByStore_StoreIdAndUserIdAndRequestedAtBetween(
+	private User authorize(Long storeId, MemberDetails member) {
+		User u = userRepository.findById(member.getId())
+			.orElseThrow(UserNotFoundException::new);
+		if (!Role.SUPER_ADMIN.equals(u.getRole()) && !storeId.equals(u.getStoreId())) {
+			throw new ReservationViewUnauthorizedException();
+		}
+		return u;
+	}
+
+	// 공통: 오늘 날짜 예약 조회
+	private Reservation findTodayReservation(Long storeId, String userId) {
+		LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+		LocalDateTime endOfDay   = LocalDate.now().atTime(LocalTime.MAX);
+
+		return reservationRepository
+			.findByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetween(
 				storeId,
 				Long.valueOf(userId),
+				List.of(ReservationStatus.WAITING, ReservationStatus.CALLING),
 				startOfDay,
 				endOfDay
 			)
 			.orElseThrow(() -> new IllegalArgumentException("오늘 날짜의 예약이 존재하지 않습니다."));
-		// 2. Redis에서 삭제
-		waitingRedisRepository.deleteWaiting(storeId, userId);
-		reservation.updateStatus(status);
-
-		// 메시지 동적 반환
-		String action = (status == ReservationStatus.CONFIRMED) ? "입장 완료" : "입장 취소";
-		return user.getNickname() + "님의 예약이 " + action + " 처리되었습니다.";
 	}
+
+	/**
+	 * 상태를 하나의 메서드에서 처리합니다.
+	 * - CALLING   : Redis 상태를 CALLING으로 변경 → DB 저장 → calledAt 반환
+	 * - CONFIRMED : Redis에서 삭제             → DB 저장 → 완료 메시지 반환
+	 * - CANCELLED : Redis에서 삭제             → DB 저장 → 취소 메시지 반환
+	 */
+	@Transactional
+	public EntryStatusResponseDto processEntryStatus(
+		Long              storeId,
+		String            userId,
+		MemberDetails     member,
+		ReservationStatus newStatus
+	) {
+		User manager = authorize(storeId, member);
+		User user = userRepository.findById(Long.valueOf(userId)).orElseThrow(UserNotFoundException::new);
+
+		String        message   = null;
+		Reservation   reservation;
+
+		switch (newStatus) {
+			case CALLING:
+				// 1) Redis 상태 검사 & 변경
+				String curr = waitingRedisRepository.getWaitingStatus(storeId, userId);
+				if (!ReservationStatus.WAITING.name().equals(curr)) {
+					throw new IllegalStateException("이미 호출되었거나 없는 예약입니다.");
+				}
+				waitingRedisRepository.setWaitingStatus(storeId, userId, ReservationStatus.CALLING.name());
+
+				// 2) 파티 인원, 호출 시각
+				Integer partySize = waitingRedisRepository.getWaitingPartySize(storeId, userId);
+				LocalDateTime now  = LocalDateTime.now();
+
+				// 3) DB에 무조건 새로 저장
+				Store store = storeRepository.getReferenceById(storeId);
+				reservation = Reservation.builder()
+					.store(store)
+					.user(user)
+					.partySize(partySize)
+					.requestedAt(now)
+					.status(ReservationStatus.CALLING)
+					.build();
+				reservationRepository.save(reservation);
+
+				break;
+
+			case CONFIRMED:
+			case CANCELLED:
+				// 1) Redis에서 제거
+				waitingRedisRepository.deleteWaiting(storeId, userId);
+
+				// 2) 오늘 날짜 예약 조회 & 상태 변경
+				reservation = findTodayReservation(storeId, userId);
+				reservation.updateStatus(newStatus);
+				reservationRepository.save(reservation);
+
+				// 3) 완료/취소 메시지
+				message = String.format(
+					"%s님의 예약이 %s 처리되었습니다.",
+					user.getNickname(),
+					newStatus == ReservationStatus.CONFIRMED ? "입장 완료" : "입장 취소"
+				);
+				break;
+
+			default:
+				throw new IllegalArgumentException("지원하지 않는 상태입니다: " + newStatus);
+		}
+
+		// 5) 공통 DTO 반환
+		return EntryStatusResponseDto.builder()
+			.id(        reservation.getId().toString())
+			.userId(    userId)
+			.partySize( reservation.getPartySize())
+			.userName(  user.getNickname())
+			.createdAt( reservation.getRequestedAt())
+			.status(    reservation.getStatus().name())
+			.message(   message)
+			.build();
+	}
+
 
 
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -1,6 +1,8 @@
 package com.nowait.applicationadmin.reservation.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -150,7 +152,7 @@ public class ReservationService {
 			.orElse(
 				Reservation.builder()
 					.store(storeRepository.getReferenceById(storeId))
-					.user(user)
+					.user(userRepository.findById(Long.valueOf(userId)).get())
 					.requestedAt(LocalDateTime.now())
 					.partySize(partySize)
 					.build()
@@ -174,11 +176,21 @@ public class ReservationService {
 			throw new ReservationViewUnauthorizedException();
 		}
 		// 1. DB status 업데이트
-		Reservation reservation = reservationRepository.findByStore_StoreIdAndUserId(storeId, Long.valueOf(userId))
-			.orElseThrow(() -> new IllegalArgumentException("해당 예약이 존재하지 않습니다."));
-		reservation.updateStatus(status);
+		LocalDate today = LocalDate.now();
+		LocalDateTime startOfDay = today.atStartOfDay();
+		LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+		Reservation reservation = reservationRepository
+			.findByStore_StoreIdAndUserIdAndRequestedAtBetween(
+				storeId,
+				Long.valueOf(userId),
+				startOfDay,
+				endOfDay
+			)
+			.orElseThrow(() -> new IllegalArgumentException("오늘 날짜의 예약이 존재하지 않습니다."));
 		// 2. Redis에서 삭제
 		waitingRedisRepository.deleteWaiting(storeId, userId);
+		reservation.updateStatus(status);
 
 		// 메시지 동적 반환
 		String action = (status == ReservationStatus.CONFIRMED) ? "입장 완료" : "입장 취소";

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/controller/ReservationController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/controller/ReservationController.java
@@ -35,8 +35,6 @@ public class ReservationController {
 	private final ReservationService reservationService;
 
 	@PostMapping("/create/{storeId}")
-	@Operation(summary = "예약 생성", description = "특정 주점에 대한 예약하기 생성")
-	@ApiResponse(responseCode = "201", description = "예약 생성")
 	public ResponseEntity<?> create(
 		@PathVariable Long storeId,
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/controller/StoreController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/controller/StoreController.java
@@ -3,6 +3,7 @@ package com.nowait.applicationuser.store.controller;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.nowait.applicationuser.store.dto.StoreWaitingInfo;
 import com.nowait.applicationuser.store.service.StoreService;
 import com.nowait.common.api.ApiUtils;
+import com.nowait.domainuserrdb.oauth.dto.CustomOAuth2User;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -48,12 +50,12 @@ public class StoreController {
 	@GetMapping("/{storeId}")
 	@Operation(summary = "주점 ID로 주점 상세 조회", description = "특정 주점을 ID로 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "주점 상세 조회 성공")
-	public ResponseEntity<?> getStoreById(@PathVariable Long storeId) {
+	public ResponseEntity<?> getStoreById(@PathVariable Long storeId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(
 				ApiUtils.success(
-					storeService.getStoreByStoreId(storeId)
+					storeService.getStoreByStoreId(storeId, customOAuth2User)
 				)
 			);
 	}

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StorePageReadDto.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StorePageReadDto.java
@@ -26,6 +26,7 @@ public class StorePageReadDto {
 	private Boolean isActive;
 	private Boolean deleted;
 	private LocalDateTime createdAt;
+	private Boolean isBookmarked;
 
 	public static StorePageReadDto fromEntity(Store store, List<StoreImageUploadResponse> allImages, String departmentName, Long waitingCount) {
 
@@ -51,6 +52,37 @@ public class StorePageReadDto {
 			.deleted(store.getDeleted())
 			.profileImage(profile)
 			.bannerImages(banners)
+			.isBookmarked(false)
+			.build();
+	}
+
+	public static StorePageReadDto fromEntityWithBookmark(
+		Store store, List<StoreImageUploadResponse> allImages, String departmentName, Long waitingCount, Boolean isBookmarked
+	) {
+
+		StoreImageUploadResponse profile = allImages.stream()
+			.filter(image -> image.getImageType() == ImageType.PROFILE)
+			.findFirst()
+			.orElse(null);
+
+		List<StoreImageUploadResponse> banners = allImages.stream()
+			.filter(image -> image.getImageType() == ImageType.BANNER)
+			.toList();
+
+		return StorePageReadDto.builder()
+			.createdAt(store.getCreatedAt())
+			.storeId(store.getStoreId())
+			.waitingCount(waitingCount)
+			.departmentId(store.getDepartmentId())
+			.departmentName(departmentName)
+			.name(store.getName())
+			.location(store.getLocation())
+			.description(store.getDescription())
+			.isActive(store.getIsActive())
+			.deleted(store.getDeleted())
+			.profileImage(profile)
+			.bannerImages(banners)
+			.isBookmarked(isBookmarked)
 			.build();
 	}
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/service/StoreService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/service/StoreService.java
@@ -9,12 +9,13 @@ import com.nowait.applicationuser.store.dto.StorePageReadDto;
 import com.nowait.applicationuser.store.dto.StoreReadDto;
 import com.nowait.applicationuser.store.dto.StoreReadResponse;
 import com.nowait.applicationuser.store.dto.StoreWaitingInfo;
+import com.nowait.domainuserrdb.oauth.dto.CustomOAuth2User;
 
 public interface StoreService {
 
 	StoreDepartmentReadResponse getAllStoresByPageAndDeparments(Pageable pageable);
 
-	StorePageReadDto getStoreByStoreId(Long storeId);
+	StorePageReadDto getStoreByStoreId(Long storeId, CustomOAuth2User customOAuth2User);
 
 	List<StorePageReadDto> searchByKeywordNative(String name);
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/service/StoreServiceImpl.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/service/StoreServiceImpl.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -17,6 +16,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +33,12 @@ import com.nowait.domaincorerdb.store.exception.StoreNotFoundException;
 import com.nowait.domaincorerdb.store.exception.StoreParamEmptyException;
 import com.nowait.domaincorerdb.store.repository.StoreImageRepository;
 import com.nowait.domaincorerdb.store.repository.StoreRepository;
+import com.nowait.domaincorerdb.user.entity.User;
+import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
+import com.nowait.domaincorerdb.user.repository.UserRepository;
 import com.nowait.domaincoreredis.common.util.RedisKeyUtils;
+import com.nowait.domainuserrdb.bookmark.repository.BookmarkRepository;
+import com.nowait.domainuserrdb.oauth.dto.CustomOAuth2User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,7 +50,8 @@ public class StoreServiceImpl implements StoreService {
 	private final StoreImageRepository storeImageRepository;
 	private final DepartmentRepository departmentRepository;
 	private final StringRedisTemplate redisTemplate;
-
+	private final BookmarkRepository bookmarkRepository;
+	private final UserRepository userRepository;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -115,8 +121,10 @@ public class StoreServiceImpl implements StoreService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public StorePageReadDto getStoreByStoreId(Long storeId) {
+	public StorePageReadDto getStoreByStoreId(Long storeId, CustomOAuth2User customOAuth2User) {
 		if (storeId == null) throw new StoreParamEmptyException();
+		User user = userRepository.findById(customOAuth2User.getUserId())
+			.orElseThrow(UserNotFoundException::new);
 
 		Store store = storeRepository.findByStoreIdAndDeletedFalse(storeId)
 			.orElseThrow(StoreNotFoundException::new);
@@ -139,7 +147,11 @@ public class StoreServiceImpl implements StoreService {
 			.map(StoreImageUploadResponse::fromEntity)
 			.toList();
 
-		return StorePageReadDto.fromEntity(store, imageDto, departmentName, waitingSize);
+		if (bookmarkRepository.existsByUserAndStore(user, store)) {
+			return StorePageReadDto.fromEntityWithBookmark(store, imageDto, departmentName, waitingSize, true);
+		} else {
+			return StorePageReadDto.fromEntity(store, imageDto, departmentName, waitingSize);
+		}
 	}
 
 	@Override

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
@@ -1,5 +1,6 @@
 package com.nowait.domaincorerdb.reservation.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +18,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	boolean existsByUserAndStoreAndStatusIn(User user, Store store, List<ReservationStatus> statuses);
 
 	Optional<Reservation> findByStore_StoreIdAndUserId(Long storeId, Long userId);
+
+	Optional<Reservation> findByStore_StoreIdAndUserIdAndRequestedAtBetween(Long storeId, Long userId, LocalDateTime start, LocalDateTime end);
+
 
 	List<Reservation> findAllByStore_StoreId(Long storeId);
 

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
@@ -21,6 +21,13 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
 	Optional<Reservation> findByStore_StoreIdAndUserIdAndRequestedAtBetween(Long storeId, Long userId, LocalDateTime start, LocalDateTime end);
 
+	Optional<Reservation> findByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetween(
+		Long storeId,
+		Long userId,
+		List<ReservationStatus> statuses,
+		LocalDateTime start,
+		LocalDateTime end
+	);
 
 	List<Reservation> findAllByStore_StoreId(Long storeId);
 


### PR DESCRIPTION
## 작업 요약
- 예약 상태 변경 시 날짜만 다른 객체 구분 가능하도록 수정
## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 예약 조회 시 당일 예약만 정확히 필터링하여 처리하도록 개선되었습니다.
  * 오늘 예약이 없는 경우 예외 메시지가 더 명확하게 안내됩니다.

* **문서**
  * 예약 생성 엔드포인트의 Swagger/OpenAPI 설명이 제거되었습니다.

* **신규 기능**
  * 매장, 사용자, 날짜 범위로 예약을 조회하는 기능이 추가되었습니다.
  * 매장 상세 조회 시 로그인한 사용자의 북마크 여부가 표시됩니다.
  * 예약 상태 변경 시 호출, 확정, 취소 상태를 하나의 통합된 응답으로 제공합니다.
  * 예약 상태 변경 관련 응답에 상세 정보와 메시지가 포함된 새로운 데이터 구조가 도입되었습니다.

* **기능 개선**
  * 예약 상태 처리 로직이 통합되어 권한 검증과 상태 변경이 일관되게 수행됩니다.
  * 예약 호출 API가 비활성화되고, 관련 상태 변경은 통합된 메서드로 대체되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->