### PR TITLE
Refactor: 웨이팅 로직 버그 해결 및 로직 개선

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
@@ -8,18 +8,15 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.nowait.applicationadmin.reservation.dto.CallingWaitingResponseDto;
 import com.nowait.applicationadmin.reservation.dto.EntryStatusResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusRequest;
 import com.nowait.applicationadmin.reservation.dto.WaitingUserResponse;
 import com.nowait.applicationadmin.reservation.service.ReservationService;
 import com.nowait.common.api.ApiUtils;
-import com.nowait.common.enums.ReservationStatus;
 import com.nowait.domaincorerdb.user.entity.MemberDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,7 +37,13 @@ public class ReservationController {
 	@ApiResponse(responseCode = "200", description = "주점별 전체 대기 리스트 조회")
 	public ResponseEntity<?> getWaitingUsersWithScore(@PathVariable Long storeId) {
 		List<WaitingUserResponse> response = reservationService.getAllWaitingUserDetails(storeId);
-		return ResponseEntity.ok(response);
+		return ResponseEntity
+			.ok()
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
 	}
 
 	@GetMapping("/admin/{storeId}/completed")
@@ -51,7 +54,13 @@ public class ReservationController {
 		@AuthenticationPrincipal MemberDetails memberDetails
 	) {
 		List<WaitingUserResponse> response = reservationService.getCompletedWaitingUserDetails(storeId);
-		return ResponseEntity.ok(response);
+		return ResponseEntity
+			.ok()
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
 	}
 
 	// @PatchMapping("/admin/{storeId}/call/{userId}")

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/EntryStatusResponseDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/EntryStatusResponseDto.java
@@ -69,14 +69,5 @@ public class EntryStatusResponseDto {
 			})
 			.build();
 	}
-
-	private String buildMessage(ReservationStatus status, String nickname) {
-		return switch (status) {
-			case CALLING -> nickname + "님을 호출하였습니다.";
-			case CONFIRMED -> nickname + "님의 입장이 완료되었습니다.";
-			case CANCELLED -> nickname + "님의 예약이 취소되었습니다.";
-			default -> "";
-		};
-	}
 }
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/EntryStatusResponseDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/EntryStatusResponseDto.java
@@ -2,6 +2,9 @@ package com.nowait.applicationadmin.reservation.dto;
 
 import java.time.LocalDateTime;
 
+import com.nowait.common.enums.ReservationStatus;
+import com.nowait.domaincorerdb.reservation.entity.Reservation;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +14,10 @@ import lombok.Getter;
 @Builder
 public class EntryStatusResponseDto {
 	@Schema(description = "예약 ID", example = "1201")
-	private String id; // reservationId
+	private String reservationId; // reservationId
+
+	@Schema(description = "예약 번호", example = "23-240504-0001")
+	private String reservationNumber;
 
 	@Schema(description = "유저 ID", example = "16")
 	private String userId;
@@ -25,6 +31,15 @@ public class EntryStatusResponseDto {
 	@Schema(description = "대기 등록 시각", example = "2025-07-22T16:00:00")
 	private LocalDateTime createdAt;
 
+	@Schema(description = "호출 시각", example = "2025-07-22T16:00:00")
+	private LocalDateTime calledAt; // 호출 시각
+
+	@Schema(description = "입장 완료 처리 시각", example = "2025-07-22T16:00:00")
+	private LocalDateTime confirmedAt; // 완료 시각
+
+	@Schema(description = "웨이팅 취소 시각", example = "2025-07-22T16:00:00")
+	private LocalDateTime cancelledAt; // 취소 시각
+
 	@Schema(description = "대기 상태", example = "CALLING")
 	private String status;
 
@@ -33,5 +48,35 @@ public class EntryStatusResponseDto {
 
 	@Schema(description = "호출 메시지", example = "호출 메시지")
 	private String message;
+
+	public static EntryStatusResponseDto fromEntity(Reservation r) {
+		return EntryStatusResponseDto.builder()
+			.reservationId(r.getId().toString())
+			.reservationNumber(r.getReservationNumber())
+			.userId(r.getUser().getId().toString())
+			.partySize(r.getPartySize())
+			.userName(r.getUser().getNickname())
+			.createdAt(r.getRequestedAt())
+			.status(r.getStatus().name())
+			.calledAt(r.getCalledAt())
+			.confirmedAt(r.getConfirmedAt())
+			.cancelledAt(r.getCancelledAt())
+			.message(switch (r.getStatus()) {
+				case CALLING   -> r.getUser().getNickname() + "님을 호출하였습니다.";
+				case CONFIRMED -> r.getUser().getNickname() + "님의 입장이 완료되었습니다.";
+				case CANCELLED -> r.getUser().getNickname() + "님의 예약이 취소되었습니다.";
+				default        -> "";
+			})
+			.build();
+	}
+
+	private String buildMessage(ReservationStatus status, String nickname) {
+		return switch (status) {
+			case CALLING -> nickname + "님을 호출하였습니다.";
+			case CONFIRMED -> nickname + "님의 입장이 완료되었습니다.";
+			case CANCELLED -> nickname + "님의 예약이 취소되었습니다.";
+			default -> "";
+		};
+	}
 }
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/WaitingUserResponse.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/WaitingUserResponse.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 public class WaitingUserResponse {
 
 	@Schema(description = "예약 ID", example = "16-20240201-0002")
-	private String reservationId;
+	private String reservationNumber;
 
 	@Schema(description = "유저 ID", example = "16")
 	private String userId;
@@ -39,7 +39,7 @@ public class WaitingUserResponse {
 
 	public static WaitingUserResponse fromEntity(Reservation reservation) {
 		return WaitingUserResponse.builder()
-			.reservationId(reservation.getId().toString())
+			.reservationNumber(reservation.getReservationNumber())
 			.userId(reservation.getUser().getId().toString())
 			.partySize(reservation.getPartySize())
 			.userName(reservation.getUser().getNickname())
@@ -50,7 +50,7 @@ public class WaitingUserResponse {
 
 	public static WaitingUserResponse fromRedis(String reservationId, String userId, Integer partySize, String userName, LocalDateTime createdAt, String status, Double score) {
 		return WaitingUserResponse.builder()
-			.reservationId(reservationId)
+			.reservationNumber(reservationId)
 			.userId(userId)
 			.partySize(partySize)
 			.userName(userName)

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/WaitingUserResponse.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/dto/WaitingUserResponse.java
@@ -16,8 +16,8 @@ import lombok.Getter;
 @Schema(description = "대기 사용자 응답 DTO")
 public class WaitingUserResponse {
 
-	@Schema(description = "예약 ID", example = "1201")
-	private String id; // reservationId
+	@Schema(description = "예약 ID", example = "16-20240201-0002")
+	private String reservationId;
 
 	@Schema(description = "유저 ID", example = "16")
 	private String userId;
@@ -39,12 +39,24 @@ public class WaitingUserResponse {
 
 	public static WaitingUserResponse fromEntity(Reservation reservation) {
 		return WaitingUserResponse.builder()
-			.id(reservation.getId().toString())
+			.reservationId(reservation.getId().toString())
 			.userId(reservation.getUser().getId().toString())
 			.partySize(reservation.getPartySize())
 			.userName(reservation.getUser().getNickname())
 			.createdAt(reservation.getRequestedAt())
 			.status(reservation.getStatus().name())
+			.build();
+	}
+
+	public static WaitingUserResponse fromRedis(String reservationId, String userId, Integer partySize, String userName, LocalDateTime createdAt, String status, Double score) {
+		return WaitingUserResponse.builder()
+			.reservationId(reservationId)
+			.userId(userId)
+			.partySize(partySize)
+			.userName(userName)
+			.createdAt(createdAt)
+			.status(status)
+			.score(score)
 			.build();
 	}
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
@@ -16,8 +16,8 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class WaitingRedisRepository {
+
 	private final StringRedisTemplate redisTemplate;
-	private final Date expireAt = RedisKeyUtils.expireAtNext03();
 
 	// 대기열 전체 인원수 조회
 	public List<ZSetOperations.TypedTuple<String>> getAllWaitingWithScore(Long storeId) {
@@ -90,7 +90,7 @@ public class WaitingRedisRepository {
 		String key = RedisKeyUtils.buildWaitingCalledAtKeyPrefix() + storeId;
 		redisTemplate.opsForHash().put(key, userId, String.valueOf(timestamp));
 
-		redisTemplate.expireAt(key, expireAt);
+		redisTemplate.expireAt(key, RedisKeyUtils.expireAtNext03());
 	}
 
 	public Long getWaitingCalledAt(Long storeId, String userId) {

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/repository/WaitingRedisRepository.java
@@ -1,7 +1,7 @@
 package com.nowait.applicationadmin.reservation.repository;
 
-import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WaitingRedisRepository {
 	private final StringRedisTemplate redisTemplate;
+	private final Date expireAt = RedisKeyUtils.expireAtNext03();
 
 	// 대기열 전체 인원수 조회
 	public List<ZSetOperations.TypedTuple<String>> getAllWaitingWithScore(Long storeId) {
@@ -54,6 +55,19 @@ public class WaitingRedisRepository {
 		return value == null ? null : Integer.valueOf(value.toString());
 	}
 
+	// ReservationNumber 조회
+	public String getReservationId(Long storeId, String userId) {
+		String status = getWaitingStatus(storeId, userId);
+		if (!"WAITING".equals(status) && !"CALLING".equals(status)) {
+			// 이미 종료된 대기라면, 예약 번호도 없던 것처럼 취급
+			return null;
+		}
+		String numberMapKey = RedisKeyUtils.buildReservationNumberKey(storeId);
+		Object val = redisTemplate.opsForHash().get(numberMapKey, userId);
+
+		return val != null ? val.toString() : null;
+	}
+
 	public void deleteWaiting(Long storeId, String userId) {
 		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
 		redisTemplate.opsForHash().delete(statusKey, userId);
@@ -63,6 +77,26 @@ public class WaitingRedisRepository {
 
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
 		redisTemplate.opsForHash().delete(partyKey, userId);
+
+		String numberMapKey  = RedisKeyUtils.buildReservationNumberKey(storeId);
+		redisTemplate.opsForHash().delete(numberMapKey, userId);
+
+		String key = RedisKeyUtils.buildWaitingCalledAtKeyPrefix() + storeId;
+		redisTemplate.opsForHash().delete(key, userId);
+	}
+
+	// 호출 시각 기록
+	public void setWaitingCalledAt(Long storeId, String userId, long timestamp) {
+		String key = RedisKeyUtils.buildWaitingCalledAtKeyPrefix() + storeId;
+		redisTemplate.opsForHash().put(key, userId, String.valueOf(timestamp));
+
+		redisTemplate.expireAt(key, expireAt);
+	}
+
+	public Long getWaitingCalledAt(Long storeId, String userId) {
+		String key = RedisKeyUtils.buildWaitingCalledAtKeyPrefix() + storeId;
+		Object val = redisTemplate.opsForHash().get(key, userId);
+		return val == null ? null : Long.valueOf(val.toString());
 	}
 }
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -287,27 +287,25 @@ public class ReservationService {
 
 					Reservation saved = reservationRepository.save(r);
 					return EntryStatusResponseDto.fromEntity(saved);
+				} else {
+					// 2) 이미 취소(CANCELLED)된 경우: DB 레코드 찾아 바로 CONFIRMED 로 전환
+					// TODO 메서드로 분리
+					LocalDateTime start = LocalDate.now().atStartOfDay();
+					LocalDateTime end = LocalDate.now().atTime(LocalTime.MAX);
+					Reservation existing = reservationRepository
+						.findFirstByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetweenOrderByRequestedAtDesc(
+							storeId,
+							Long.valueOf(userId),
+							List.of(ReservationStatus.CANCELLED),
+							start,
+							end
+						).orElseThrow(() -> new IllegalStateException("취소된 예약이 없습니다."));
+
+					existing.markConfirmed(now);
+					existing.updateStatus(ReservationStatus.CONFIRMED);
+					Reservation saved = reservationRepository.save(existing);
+					return EntryStatusResponseDto.fromEntity(saved);
 				}
-
-				// 2) 이미 취소(CANCELLED)된 경우: DB 레코드 찾아 바로 CONFIRMED 로 전환
-				//    (Redis에는 상태가 남아있지 않으므로 currStatus==null)
-			{
-				LocalDateTime start = LocalDate.now().atStartOfDay();
-				LocalDateTime end = LocalDate.now().atTime(LocalTime.MAX);
-				Reservation existing = reservationRepository
-					.findFirstByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetweenOrderByRequestedAtDesc(
-						storeId,
-						Long.valueOf(userId),
-						List.of(ReservationStatus.CANCELLED),
-						start,
-						end
-					).orElseThrow(() -> new IllegalStateException("취소된 예약이 없습니다."));
-
-				existing.markConfirmed(now);
-				existing.updateStatus(ReservationStatus.CONFIRMED);
-				Reservation saved = reservationRepository.save(existing);
-				return EntryStatusResponseDto.fromEntity(saved);
-			}
 
 			case CANCELLED:
 				if (!(ReservationStatus.WAITING.name().equals(currStatus)

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -1,20 +1,25 @@
 package com.nowait.applicationadmin.reservation.service;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nowait.applicationadmin.reservation.dto.CallGetResponseDto;
-import com.nowait.applicationadmin.reservation.dto.CallingWaitingResponseDto;
 import com.nowait.applicationadmin.reservation.dto.EntryStatusResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationGetResponseDto;
 import com.nowait.applicationadmin.reservation.dto.ReservationStatusSummaryDto;
@@ -28,12 +33,12 @@ import com.nowait.domaincorerdb.reservation.exception.ReservationNotFoundExcepti
 import com.nowait.domaincorerdb.reservation.exception.ReservationUpdateUnauthorizedException;
 import com.nowait.domaincorerdb.reservation.exception.ReservationViewUnauthorizedException;
 import com.nowait.domaincorerdb.reservation.repository.ReservationRepository;
-import com.nowait.domaincorerdb.store.entity.Store;
 import com.nowait.domaincorerdb.store.repository.StoreRepository;
 import com.nowait.domaincorerdb.user.entity.MemberDetails;
 import com.nowait.domaincorerdb.user.entity.User;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
 import com.nowait.domaincorerdb.user.repository.UserRepository;
+import com.nowait.domaincoreredis.common.util.RedisKeyUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,6 +50,7 @@ public class ReservationService {
 	private final UserRepository userRepository;
 	private final WaitingRedisRepository waitingRedisRepository;
 	private final StoreRepository storeRepository;
+	private final RedisTemplate redisTemplate;
 
 	//TODO 성능 비교를 위해 남겨둔 로직
 	@Transactional(readOnly = true)
@@ -98,50 +104,74 @@ public class ReservationService {
 	}
 
 	// Redis queue에 있는 주점별 전체 대기열 조회
+	//TODO 개선필요 -> createAt 정확성 및 reservationhId 생성 방법(예약생성부터 DB에 박아야하나....)
 	@Transactional(readOnly = true)
 	public List<WaitingUserResponse> getAllWaitingUserDetails(Long storeId) {
+
+		// 1) Redis로부터 전체 대기 userId + score(등록 시각)
 		List<ZSetOperations.TypedTuple<String>> waitingList = waitingRedisRepository.getAllWaitingWithScore(storeId);
 		System.out.println(waitingList);
+		if (waitingList.isEmpty()) {
+			return List.of();
+		}
 
-		// TODO N + 1 발생 -> 개선 필요
-		return waitingList.stream()
-			.map(tuple -> {
-				String userId = tuple.getValue();
-
-				// 1. Redis에서 partySize/status 조회
-				Integer partySize = waitingRedisRepository.getWaitingPartySize(storeId, userId);
-				String status = waitingRedisRepository.getWaitingStatus(storeId, userId);
-
-				// 2. DB에서 userName, createdAt, reservationId 조회
-				//TODO 개선필요 -> createAt 정확성 및 reservationhId 생성 방법(예약생성부터 DB에 박아야하나....)
-				String userName = userRepository.getReferenceById(Long.valueOf(userId)).getNickname();
-				LocalDateTime createdAt = LocalDateTime.now();
-				String reservationId = String.valueOf(
-					ThreadLocalRandom.current().nextInt(1, 100));
-
-				Optional<Reservation> reservationOpt = reservationRepository.findFirstByStore_StoreIdAndUserIdAndRequestedAtBetweenOrderByRequestedAtDesc(
-					storeId, Long.valueOf(userId), LocalDate.now().atStartOfDay(),
-					LocalDate.now().atTime(LocalTime.MAX));
-				if (reservationOpt.isPresent()) {
-					Reservation reservation = reservationOpt.get();
-					createdAt = reservation.getRequestedAt();
-					reservationId = reservation.getId().toString();
-					userName = reservation.getUser().getNickname();
-				} else {
-				}
-
-				return new WaitingUserResponse(
-					reservationId != null ? reservationId.toString() : null,
-					userId,
-					partySize,
-					userName,
-					createdAt,
-					status,
-					tuple.getScore()
-				);
-			})
+		// 2) userId 목록 분리
+		List<String> userIds = waitingList.stream()
+			.map(ZSetOperations.TypedTuple::getValue)
 			.toList();
 
+		// 3) User 닉네임을 한 번에 배치 조회
+		List<Long> userIdLongs = userIds.stream()
+			.map(Long::valueOf)
+			.toList();
+		Map<String, String> nicknameMap = userRepository.findAllById(userIdLongs).stream()
+			.collect(Collectors.toMap(
+				u -> u.getId().toString(),
+				User::getNickname
+			));
+
+		// 4) Redis 파이프라인: partySize, status, reservationId
+		String pk = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
+		String sk = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
+		String nk = RedisKeyUtils.buildReservationNumberKey(storeId);
+		String qk = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
+
+		List<Object> pipeline = redisTemplate.executePipelined((RedisCallback<Object>)conn -> {
+			byte[] uid;
+			for (String userId : userIds) {
+				uid = redisTemplate.getStringSerializer().serialize(userId);
+				conn.hGet(pk.getBytes(), uid);   // partySize
+				conn.hGet(sk.getBytes(), uid);   // status
+				conn.hGet(nk.getBytes(), uid);   // reservationId
+				conn.zScore(qk.getBytes(), uid); // score (등록 시각)
+			}
+			return null;
+		});
+
+		// 5) 결과 매핑
+		List<WaitingUserResponse> result = new ArrayList<>(userIds.size());
+		Iterator<Object> it = pipeline.iterator();
+		ZoneId zone = ZoneId.of("Asia/Seoul");
+
+		for (ZSetOperations.TypedTuple<String> tuple : waitingList) {
+			String userId = tuple.getValue();
+			Integer partySize = Optional.ofNullable((String)it.next()).map(Integer::valueOf).orElse(0);
+			String status = (String)it.next();
+			String reservationId = (String)it.next();
+			Double score = (Double)it.next();
+
+			// score → createdAt
+			LocalDateTime createdAt = score != null
+				? Instant.ofEpochMilli(score.longValue()).atZone(zone).toLocalDateTime()
+				: null;
+
+			String userName = nicknameMap.getOrDefault(userId, "Unknown");
+
+			result.add(
+				WaitingUserResponse.fromRedis(reservationId, userId, partySize, userName, createdAt, status, score));
+		}
+
+		return result;
 	}
 
 	// 완료 or 취소 처리된 대기 리스트 조회
@@ -190,77 +220,117 @@ public class ReservationService {
 	 * - CANCELLED : Redis에서 삭제             → DB 저장 → 취소 메시지 반환
 	 */
 	@Transactional
-	public EntryStatusResponseDto processEntryStatus(
-		Long storeId,
-		String userId,
-		MemberDetails member,
-		ReservationStatus newStatus
-	) {
-		User manager = authorize(storeId, member);
-		User user = userRepository.findById(Long.valueOf(userId)).orElseThrow(UserNotFoundException::new);
+	public EntryStatusResponseDto processEntryStatus(Long storeId, String userId, MemberDetails member, ReservationStatus newStatus) {
 
-		String message = null;
-		Reservation reservation;
+		authorize(storeId, member);
+
+		String queueKey = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
+
+		// Redis에서 상태·score·partySize·calledAt 조회
+		String reservationNumber = waitingRedisRepository.getReservationId(storeId, userId);
+		String currStatus = waitingRedisRepository.getWaitingStatus(storeId, userId);
+		Double score = redisTemplate.opsForZSet().score(queueKey, userId);
+		Integer partySize = waitingRedisRepository.getWaitingPartySize(storeId, userId);
+		Long calledMillis = waitingRedisRepository.getWaitingCalledAt(storeId, userId);
+
+		LocalDateTime requestedAt = score != null
+			? Instant.ofEpochMilli(score.longValue()).atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+			: LocalDateTime.now();
+		LocalDateTime calledAt = calledMillis != null
+			? Instant.ofEpochMilli(calledMillis).atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+			: null;
+		LocalDateTime now = LocalDateTime.now();
 
 		switch (newStatus) {
 			case CALLING:
-				// 1) Redis 상태 검사 & 변경
-				String curr = waitingRedisRepository.getWaitingStatus(storeId, userId);
-				if (!ReservationStatus.WAITING.name().equals(curr)) {
-					throw new IllegalStateException("이미 호출되었거나 없는 예약입니다.");
+				if (!ReservationStatus.WAITING.name().equals(currStatus)) {
+					throw new IllegalStateException("WAITING 상태에서만 CALLING 가능합니다.");
 				}
 				waitingRedisRepository.setWaitingStatus(storeId, userId, ReservationStatus.CALLING.name());
+				waitingRedisRepository.setWaitingCalledAt(storeId, userId, now.toInstant(ZoneOffset.ofHours(9)).toEpochMilli());
 
-				// 2) 파티 인원, 호출 시각
-				Integer partySize = waitingRedisRepository.getWaitingPartySize(storeId, userId);
-				LocalDateTime now = LocalDateTime.now();
 
-				// 3) DB에 무조건 새로 저장
-				Store store = storeRepository.getReferenceById(storeId);
-				reservation = Reservation.builder()
-					.store(store)
-					.user(user)
+				return EntryStatusResponseDto.builder()
+					.reservationNumber(reservationNumber)
+					.userId(userId)
 					.partySize(partySize)
-					.requestedAt(now)
-					.status(ReservationStatus.CALLING)
+					.userName(userRepository.getReferenceById(Long.valueOf(userId)).getNickname())
+					.createdAt(requestedAt)
+					.status("CALLING")
+					.score(score)
+					.calledAt(now)
+					.message("호출되었습니다.")
 					.build();
-				reservationRepository.save(reservation);
-
-				break;
 
 			case CONFIRMED:
+				// 1) 기존 대기 중이거나 호출 중일 때: Redis → DB 최초 저장
+				if (ReservationStatus.WAITING.name().equals(currStatus) || ReservationStatus.CALLING.name().equals(currStatus)) {
+
+					// Redis 전부 삭제
+					waitingRedisRepository.deleteWaiting(storeId, userId);
+
+					// 새 Reservation 생성 & 저장
+					Reservation r = Reservation.builder()
+						.reservationNumber(reservationNumber)
+						.store(storeRepository.getReferenceById(storeId))
+						.user(userRepository.getReferenceById(Long.valueOf(userId)))
+						.partySize(partySize)
+						.requestedAt(requestedAt)
+						.build();
+					// 호출 시각 반영
+					r.markCalling(calledAt != null ? calledAt : now);
+					if (newStatus == ReservationStatus.CONFIRMED) {
+						r.markConfirmed(now);
+					} else {
+						r.markCancelled(now);
+					}
+
+					Reservation saved = reservationRepository.save(r);
+					return EntryStatusResponseDto.fromEntity(saved);
+				}
+
+				// 2) 이미 취소(CANCELLED)된 경우: DB 레코드 찾아 바로 CONFIRMED 로 전환
+				//    (Redis에는 상태가 남아있지 않으므로 currStatus==null)
+			{
+				LocalDateTime start = LocalDate.now().atStartOfDay();
+				LocalDateTime end = LocalDate.now().atTime(LocalTime.MAX);
+				Reservation existing = reservationRepository
+					.findFirstByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetweenOrderByRequestedAtDesc(
+						storeId,
+						Long.valueOf(userId),
+						List.of(ReservationStatus.CANCELLED),
+						start,
+						end
+					).orElseThrow(() -> new IllegalStateException("취소된 예약이 없습니다."));
+
+				existing.markConfirmed(now);
+				existing.updateStatus(ReservationStatus.CONFIRMED);
+				Reservation saved = reservationRepository.save(existing);
+				return EntryStatusResponseDto.fromEntity(saved);
+			}
+
 			case CANCELLED:
-				// 1) Redis에서 제거
+				if (!(ReservationStatus.WAITING.name().equals(currStatus)
+					  || ReservationStatus.CALLING.name().equals(currStatus))) {
+					throw new IllegalStateException("WAITING/CALLING 상태에서만 취소 가능합니다.");
+				}
 				waitingRedisRepository.deleteWaiting(storeId, userId);
 
-				// 2) 오늘 날짜 예약 조회 & 상태 변경
-				reservation = findTodayReservation(storeId, userId);
-				reservation.updateStatus(newStatus);
-				reservationRepository.save(reservation);
-
-				// 3) 완료/취소 메시지
-				message = String.format(
-					"%s님의 예약이 %s 처리되었습니다.",
-					user.getNickname(),
-					newStatus == ReservationStatus.CONFIRMED ? "입장 완료" : "입장 취소"
-				);
-				break;
+				Reservation r = Reservation.builder()
+					.reservationNumber(reservationNumber)
+					.store(storeRepository.getReferenceById(storeId))
+					.user(userRepository.getReferenceById(Long.valueOf(userId)))
+					.partySize(partySize)
+					.requestedAt(requestedAt)
+					.build();
+				r.markCalling(calledAt != null ? calledAt : now);
+				r.markCancelled(now);
+				Reservation saved = reservationRepository.save(r);
+				return EntryStatusResponseDto.fromEntity(saved);
 
 			default:
-				throw new IllegalArgumentException("지원하지 않는 상태입니다: " + newStatus);
+				throw new IllegalArgumentException("지원하지 않는 상태: " + newStatus);
 		}
-
-		// 5) 공통 DTO 반환
-		return EntryStatusResponseDto.builder()
-			.id(reservation.getId().toString())
-			.userId(userId)
-			.partySize(reservation.getPartySize())
-			.userName(user.getNickname())
-			.createdAt(reservation.getRequestedAt())
-			.status(reservation.getStatus().name())
-			.message(message)
-			.build();
 	}
-
 }
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -247,7 +247,7 @@ public class ReservationService {
 					throw new IllegalStateException("WAITING 상태에서만 CALLING 가능합니다.");
 				}
 				waitingRedisRepository.setWaitingStatus(storeId, userId, ReservationStatus.CALLING.name());
-				waitingRedisRepository.setWaitingCalledAt(storeId, userId, now.toInstant(ZoneOffset.ofHours(9)).toEpochMilli());
+				waitingRedisRepository.setWaitingCalledAt(storeId, userId, now.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli());
 
 
 				return EntryStatusResponseDto.builder()

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/controller/ReservationController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/controller/ReservationController.java
@@ -57,7 +57,7 @@ public class ReservationController {
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
 		@RequestBody ReservationCreateRequestDto requestDto
 	) {
-		WaitingResponseDto response = reservationService.registerWaiting(storeId,customOAuth2User,requestDto);
+		WaitingResponseDto response = reservationService.registerWaiting(storeId, customOAuth2User, requestDto);
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(
@@ -74,7 +74,7 @@ public class ReservationController {
 		@PathVariable Long storeId,
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User
 	) {
-		WaitingResponseDto response = reservationService.myWaitingInfo(storeId,customOAuth2User);
+		WaitingResponseDto response = reservationService.myWaitingInfo(storeId, customOAuth2User);
 		return ResponseEntity
 			.ok()
 			.body(
@@ -95,7 +95,7 @@ public class ReservationController {
 			.ok()
 			.body(
 				ApiUtils.success(
-					reservationService.cancelWaiting(storeId,customOAuth2User)
+					reservationService.cancelWaiting(storeId, customOAuth2User)
 				)
 			);
 	}
@@ -105,7 +105,13 @@ public class ReservationController {
 	@ApiResponse(responseCode = "200", description = "대기열 리스트 조회")
 	public ResponseEntity<?> getAllMyWaitings(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 		List<MyWaitingQueueDto> response = reservationService.getAllMyWaitings(customOAuth2User);
-		return ResponseEntity.ok(ApiUtils.success(response));
+		return ResponseEntity
+			.ok()
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
 	}
 
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/dto/MyWaitingQueueDto.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/dto/MyWaitingQueueDto.java
@@ -1,6 +1,7 @@
 package com.nowait.applicationuser.reservation.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Schema(description = "내 대기 큐 정보 DTO")
 public class MyWaitingQueueDto {
+	@Schema(description = "예약 ID", example = "1-20240720-0001")
+	private String  reservationId;
 	@Schema(description = "주점 ID", example = "1")
 	private Long storeId;
 	@Schema(description = "주점 이름", example = "비어파티")
@@ -34,5 +37,7 @@ public class MyWaitingQueueDto {
 	private String location;
 	@Schema(description = "프로필 이미지 URL", example = "https://cdn.gtable.com/profile/user1.jpg")
 	private String profileImageUrl;
+	@Schema(description = "배너 이미지 URL", example = "https://cdn.gtable.com/profile/user1.jpg")
+	private List<String> bannerImageUrl;
 }
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/dto/MyWaitingStoreInfo.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/dto/MyWaitingStoreInfo.java
@@ -1,0 +1,13 @@
+package com.nowait.applicationuser.reservation.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MyWaitingStoreInfo {
+	private final Long storeId;
+	private final String storeName;
+	private final String departmentName;
+	private final String location;
+}

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/dto/WaitingResponseDto.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/dto/WaitingResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class WaitingResponseDto {
+	private final String reservationNumber;
 	private final int rank;
 	private final boolean reserved; // true면 예약, false면 대기
 	private final int partySize;

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
@@ -36,8 +36,8 @@ public class WaitingUserRedisRepository {
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
 		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
 
-		String seqKey        = RedisKeyUtils.buildReservationSeqKey(storeId);
-		String numberMapKey  = RedisKeyUtils.buildReservationNumberKey(storeId);
+		String seqKey = RedisKeyUtils.buildReservationSeqKey(storeId);
+		String numberMapKey = RedisKeyUtils.buildReservationNumberKey(storeId);
 
 		Boolean added = redisTemplate.opsForZSet().addIfAbsent(queueKey, userId, timestamp);
 		String reservationId;
@@ -64,7 +64,7 @@ public class WaitingUserRedisRepository {
 			redisTemplate.opsForHash().put(partyKey, userId, partySize.toString());
 			redisTemplate.opsForHash().put(statusKey, userId, "WAITING");
 
-			Duration ttl = setTTL(partyKey, statusKey, userId, partySize);
+			Duration ttl = calculateTTLUntilNext03AM();
 
 			redisTemplate.expire(queueKey, ttl);
 			redisTemplate.expire(partyKey, ttl);
@@ -148,7 +148,7 @@ public class WaitingUserRedisRepository {
 
 		// 3) 파이프라인으로 zRank 한 번에 조회
 		List<Object> pipelineResults = redisTemplate.executePipelined(
-			(RedisCallback<Object>) conn -> {
+			(RedisCallback<Object>)conn -> {
 				byte[] uid = redisTemplate.getStringSerializer().serialize(userId);
 				for (String key : zsetKeys) {
 					byte[] rawKey = redisTemplate.getStringSerializer().serialize(key);
@@ -191,15 +191,12 @@ public class WaitingUserRedisRepository {
 		return val != null ? val.toString() : null;
 	}
 
-	public Duration setTTL(String partyKey, String statusKey, String userId, Integer partySize) {
-		// 6) 기존 partySize, status, TTL 설정
-		redisTemplate.opsForHash().put(partyKey, userId, partySize.toString());
-		redisTemplate.opsForHash().put(statusKey, userId, "WAITING");
-
+	public Duration calculateTTLUntilNext03AM() {
 		// 6-1) Asia/Seoul 기준으로 오늘 자정(내일 00:00) 구하기
 		ZoneId zone = ZoneId.of("Asia/Seoul");
-		LocalDateTime now      = LocalDateTime.now(zone);
+		LocalDateTime now = LocalDateTime.now(zone);
 		LocalDateTime midnight = now.toLocalDate().plusDays(1).atTime(3, 0);
+
 		// 6-2) TTL 남은 초 계산
 		long secondsUntilMidnight = now.until(midnight, ChronoUnit.SECONDS);
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/repository/WaitingUserRedisRepository.java
@@ -1,10 +1,22 @@
 package com.nowait.applicationuser.reservation.repository;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -19,21 +31,50 @@ public class WaitingUserRedisRepository {
 
 	// 중복 등록 방지: 이미 있으면 추가X
 	// 특정 주점에 대한 예약 등록
-	public boolean addToWaitingQueue(Long storeId, String userId, Integer partySize, long timestamp) {
+	public String addToWaitingQueue(Long storeId, String userId, Integer partySize, long timestamp) {
 		String queueKey = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
 		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
 
+		String seqKey        = RedisKeyUtils.buildReservationSeqKey(storeId);
+		String numberMapKey  = RedisKeyUtils.buildReservationNumberKey(storeId);
+
 		Boolean added = redisTemplate.opsForZSet().addIfAbsent(queueKey, userId, timestamp);
+		String reservationId;
+
 		if (Boolean.TRUE.equals(added)) {
+
+			// 2) 일일 시퀀스: 날짜별로 초기화하려면
+			String today = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE); // YYYYMMDD
+			String dailySeqKey = seqKey + ":" + today;  // ex. reservation:seq:5:20250728
+
+			// atomic increment
+			Long seq = redisTemplate.opsForValue().increment(dailySeqKey, 1);
+
+			// 3) 4자리 0패딩
+			String seqStr = String.format("%04d", seq);
+
+			// 4) 최종 ID 조합
+			reservationId = storeId + "-" + today + "-" + seqStr;
+
+			// 5) Hash에 저장
+			redisTemplate.opsForHash().put(numberMapKey, userId, reservationId);
+
+			// 6) 기존 partySize, status, TTL 설정
 			redisTemplate.opsForHash().put(partyKey, userId, partySize.toString());
 			redisTemplate.opsForHash().put(statusKey, userId, "WAITING");
-			// TTL 12시간(43200초) 설정
-			redisTemplate.expire(queueKey, Duration.ofHours(12));
-			redisTemplate.expire(partyKey, Duration.ofHours(12));
-			redisTemplate.expire(statusKey, Duration.ofHours(12));
+
+			Duration ttl = setTTL(partyKey, statusKey, userId, partySize);
+
+			redisTemplate.expire(queueKey, ttl);
+			redisTemplate.expire(partyKey, ttl);
+			redisTemplate.expire(statusKey, ttl);
+		} else {
+			Object stored = redisTemplate.opsForHash().get(numberMapKey, userId);
+			reservationId = stored != null ? stored.toString() : null;
 		}
-		return Boolean.TRUE.equals(added);
+
+		return reservationId;
 	}
 
 	// 예약한 사람이 등록한 동반인원(partySize) 조회
@@ -54,9 +95,11 @@ public class WaitingUserRedisRepository {
 		String key = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
 		String partyKey = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
 		String statusKey = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
+		String reservationNumberKey = RedisKeyUtils.buildReservationNumberKey(storeId);
 		redisTemplate.opsForZSet().remove(key, userId);
 		redisTemplate.opsForHash().delete(partyKey, userId);
 		redisTemplate.opsForHash().delete(statusKey, userId);
+		redisTemplate.opsForHash().delete(reservationNumberKey, userId);
 		return true;
 	}
 
@@ -69,21 +112,59 @@ public class WaitingUserRedisRepository {
 
 	// 사용자가 대기중인 전체 매장 목록 조회
 	public List<Long> getUserWaitingStoreIds(String userId) {
-		// key pattern으로 모든 매장 대기열 조회 (keys: waiting:*)
-		Set<String> keys = redisTemplate.keys(RedisKeyUtils.buildWaitingKeyPrefix() + "*");
-		if (keys == null)
-			return List.of();
+		String prefix = RedisKeyUtils.buildWaitingKeyPrefix();
+		String pattern = prefix + "*";
 
-		List<Long> result = new ArrayList<>();
-		for (String key : keys) {
-			// ZSet만 필터링
-			String type = redisTemplate.type(key).code();
-			if (!"zset".equals(type)) {
-				continue; // hash 등은 스킵!
+		// 1) SCAN 으로 모든 키 수집
+		Set<String> matchingKeys = new HashSet<>();
+		ScanOptions options = ScanOptions.scanOptions()
+			.match(pattern)
+			.count(500)   // 한 번에 스캔할 예상 키 개수 힌트 (조정 가능)
+			.build();
+
+		// 2) Cursor 로 비차단 스캔
+		try (Cursor<byte[]> cursor =
+				 redisTemplate.getConnectionFactory()
+					 .getConnection()
+					 .scan(options)) {
+			while (cursor.hasNext()) {
+				String key = new String(cursor.next(), StandardCharsets.UTF_8);
+				matchingKeys.add(key);
 			}
-			// waiting:{storeId}만 추출 (waiting:party:7 등은 통과 안 됨)
-			Long storeId = Long.valueOf(key.substring(key.lastIndexOf(":") + 1));
-			if (redisTemplate.opsForZSet().rank(key, userId) != null) {
+		}
+
+		if (matchingKeys.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		// 2) ZSet 타입 키만 필터링
+		List<String> zsetKeys = matchingKeys.stream()
+			.filter(key -> "zset".equals(redisTemplate.type(key).code()))
+			.toList();
+
+		if (zsetKeys.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		// 3) 파이프라인으로 zRank 한 번에 조회
+		List<Object> pipelineResults = redisTemplate.executePipelined(
+			(RedisCallback<Object>) conn -> {
+				byte[] uid = redisTemplate.getStringSerializer().serialize(userId);
+				for (String key : zsetKeys) {
+					byte[] rawKey = redisTemplate.getStringSerializer().serialize(key);
+					conn.zRank(rawKey, uid);
+				}
+				return null;
+			}
+		);
+
+		// 4) zsetKeys 로 루프를 돌며 결과 매핑
+		List<Long> result = new ArrayList<>();
+		Iterator<Object> it = pipelineResults.iterator();
+		for (String key : zsetKeys) {
+			Object rankObj = it.next();   // pipelineResults 개수와 정확히 매칭
+			if (rankObj != null) {
+				long storeId = Long.parseLong(key.substring(prefix.length()));
 				result.add(storeId);
 			}
 		}
@@ -100,6 +181,29 @@ public class WaitingUserRedisRepository {
 	// 사용자가 해당 스토어 대기열에 있는지 여부 반환
 	public boolean isUserWaiting(Long storeId, String userId) {
 		return getRank(storeId, userId) != null;
+	}
+
+	// ReservationNumber 조회
+	public String getReservationId(Long storeId, String userId) {
+		String numberMapKey = RedisKeyUtils.buildReservationNumberKey(storeId);
+		Object val = redisTemplate.opsForHash().get(numberMapKey, userId);
+
+		return val != null ? val.toString() : null;
+	}
+
+	public Duration setTTL(String partyKey, String statusKey, String userId, Integer partySize) {
+		// 6) 기존 partySize, status, TTL 설정
+		redisTemplate.opsForHash().put(partyKey, userId, partySize.toString());
+		redisTemplate.opsForHash().put(statusKey, userId, "WAITING");
+
+		// 6-1) Asia/Seoul 기준으로 오늘 자정(내일 00:00) 구하기
+		ZoneId zone = ZoneId.of("Asia/Seoul");
+		LocalDateTime now      = LocalDateTime.now(zone);
+		LocalDateTime midnight = now.toLocalDate().plusDays(1).atTime(3, 0);
+		// 6-2) TTL 남은 초 계산
+		long secondsUntilMidnight = now.until(midnight, ChronoUnit.SECONDS);
+
+		return Duration.ofSeconds(secondsUntilMidnight);
 	}
 }
 

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
@@ -4,16 +4,21 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nowait.applicationuser.reservation.dto.MyWaitingQueueDto;
+import com.nowait.applicationuser.reservation.dto.MyWaitingStoreInfo;
 import com.nowait.applicationuser.reservation.dto.ReservationCreateRequestDto;
 import com.nowait.applicationuser.reservation.dto.ReservationCreateResponseDto;
 import com.nowait.applicationuser.reservation.dto.WaitingResponseDto;
@@ -25,13 +30,17 @@ import com.nowait.domaincorerdb.department.repository.DepartmentRepository;
 import com.nowait.domaincorerdb.reservation.entity.Reservation;
 import com.nowait.domaincorerdb.reservation.exception.DuplicateReservationException;
 import com.nowait.domaincorerdb.reservation.repository.ReservationRepository;
+import com.nowait.domaincorerdb.store.entity.ImageType;
 import com.nowait.domaincorerdb.store.entity.Store;
+import com.nowait.domaincorerdb.store.entity.StoreImage;
 import com.nowait.domaincorerdb.store.exception.StoreNotFoundException;
 import com.nowait.domaincorerdb.store.exception.StoreWaitingDisabledException;
+import com.nowait.domaincorerdb.store.repository.StoreImageRepository;
 import com.nowait.domaincorerdb.store.repository.StoreRepository;
 import com.nowait.domaincorerdb.user.entity.User;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
 import com.nowait.domaincorerdb.user.repository.UserRepository;
+import com.nowait.domaincoreredis.common.util.RedisKeyUtils;
 import com.nowait.domainuserrdb.oauth.dto.CustomOAuth2User;
 
 import lombok.RequiredArgsConstructor;
@@ -45,15 +54,18 @@ public class ReservationService {
 	private final UserRepository userRepository;
 	private final WaitingUserRedisRepository waitingUserRedisRepository;
 	private final DepartmentRepository departmentRepository;
+	private final StoreImageRepository storeImageRepository;
+	private final RedisTemplate redisTemplate;
 
 	public WaitingResponseDto registerWaiting(
-		Long storeId,CustomOAuth2User customOAuth2User,ReservationCreateRequestDto requestDto
+		Long storeId, CustomOAuth2User customOAuth2User, ReservationCreateRequestDto requestDto
 	) {
 		// Store 유효성 검증 추가
 		Store store = storeRepository.findById(storeId)
 			.orElseThrow(StoreNotFoundException::new);
 		if (Boolean.FALSE.equals(store.getIsActive()))
 			throw new StoreWaitingDisabledException();
+
 		// User Role 검증 추가
 		User user = userRepository.findById(customOAuth2User.getUserId())
 			.orElseThrow(UserNotFoundException::new);
@@ -65,13 +77,16 @@ public class ReservationService {
 		long timestamp = System.currentTimeMillis();
 
 		// 예약 신청 유저 큐(queue)에 추가
-		boolean added = waitingUserRedisRepository.addToWaitingQueue(storeId, userId, requestDto.getPartySize(), timestamp);
-		if (!added) {
-			throw new IllegalArgumentException("Failed to add to waiting queue");
+		String reservationId = waitingUserRedisRepository.addToWaitingQueue(storeId, userId, requestDto.getPartySize(),
+			timestamp);
+		if (reservationId == null) {
+			throw new IllegalStateException("예약 번호 발급 실패");
 		}
+
 		// 신규 등록/기존 등록 관계없이 내 순번, 전체 인원 반환
 		Long rank = waitingUserRedisRepository.getRank(storeId, userId);
 		return WaitingResponseDto.builder()
+			.reservationNumber(reservationId)
 			.rank(rank == null ? -1 : rank.intValue() + 1)
 			.partySize(requestDto.getPartySize() == null ? 0 : requestDto.getPartySize())
 			.build();
@@ -81,11 +96,13 @@ public class ReservationService {
 		String userId = customOAuth2User.getUserId().toString();
 		// 입력 검증 추가
 		if (storeId == null || userId.trim().isEmpty()) {
-		throw new IllegalArgumentException("Invalid storeId or userId");
+			throw new IllegalArgumentException("Invalid storeId or userId");
 		}
 		Long rank = waitingUserRedisRepository.getRank(storeId, userId);
 		Integer partySize = waitingUserRedisRepository.getPartySize(storeId, userId);
+		String reservationId = waitingUserRedisRepository.getReservationId(storeId, userId);
 		return WaitingResponseDto.builder()
+			.reservationNumber(reservationId)
 			.rank(rank == null ? -1 : rank.intValue() + 1)
 			.partySize(partySize == null ? 0 : partySize)
 			.build();
@@ -103,53 +120,101 @@ public class ReservationService {
 		}
 		return removed;
 	}
+
 	//TODO 성능 개선 필요
 	public List<MyWaitingQueueDto> getAllMyWaitings(CustomOAuth2User customOAuth2User) {
 		String userId = customOAuth2User.getUserId().toString();
-		List<Long> userWaitingStoreIds = waitingUserRedisRepository.getUserWaitingStoreIds(userId);
 
-		List<MyWaitingQueueDto> result = new ArrayList<>();
-		if (!userWaitingStoreIds.isEmpty()) {
-			// Store, Department 배치 조회
-			List<Store> stores = storeRepository.findAllById(userWaitingStoreIds);
-			Map<Long, Store> storeMap = stores.stream()
-				.collect(Collectors.toMap(Store::getStoreId, Function.identity()));
+		// 1) 현재 SCAN 기반으로 얻어온 storeId 리스트
+		List<Long> storeIds = waitingUserRedisRepository.getUserWaitingStoreIds(userId);
+		if (storeIds.isEmpty())
+			return Collections.emptyList();
 
-			Set<Long> departmentIds = stores.stream()
-				.map(Store::getDepartmentId)
-				.collect(Collectors.toSet());
-			Map<Long, String> departmentNameMap = departmentRepository.findAllById(departmentIds).stream()
-				.collect(Collectors.toMap(Department::getId, Department::getName));
+		// 2) Store, Department 배치 조회
+		List<Store> stores = storeRepository.findAllWithDepartmentByStoreIdIn(storeIds);
+		Map<Long, Store> storeMap = stores.stream()
+			.collect(Collectors.toMap(Store::getStoreId, Function.identity()));
 
-			for (Long storeId : userWaitingStoreIds) {
-				Store store = storeMap.get(storeId);
-				if (store == null) continue;
+		// 3) Department 이름 조회 (departmentId 기준)
+		Set<Long> deptIds = stores.stream()
+			.map(Store::getDepartmentId)
+			.collect(Collectors.toSet());
+		Map<Long, String> deptNameMap = departmentRepository.findAllById(deptIds).stream()
+			.collect(Collectors.toMap(Department::getId, Department::getName));
 
-				Long rank = waitingUserRedisRepository.getRank(storeId, userId);
-				Integer partySize = waitingUserRedisRepository.getPartySize(storeId, userId);
-				Long timestamp = waitingUserRedisRepository.getWaitingTimestamp(storeId, userId);
+		// 4) StoreImage 조회 (프로필 + 배너)
+		List<ImageType> neededTypes = List.of(ImageType.PROFILE, ImageType.BANNER);
+		List<StoreImage> images = storeImageRepository.findAllByStore_StoreIdInAndImageTypeIn(storeIds, neededTypes);
 
-				LocalDateTime registeredAt = timestamp != null
-					? LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.of("Asia/Seoul"))
-					: null;
+		Map<Long, String> profileMap = images.stream()
+			.filter(img -> img.getImageType() == ImageType.PROFILE)
+			.collect(Collectors.toMap(
+				img -> img.getStore().getStoreId(),
+				StoreImage::getImageUrl,
+				(first, second) -> first
+			));
+		Map<Long, List<String>> bannerMap = images.stream()
+			.filter(img -> img.getImageType() == ImageType.BANNER)
+			.collect(Collectors.groupingBy(
+				img -> img.getStore().getStoreId(),
+				Collectors.mapping(StoreImage::getImageUrl, Collectors.toList())
+			));
 
-				result.add(MyWaitingQueueDto.builder()
-					.storeId(storeId)
-					.storeName(store.getName())
-					.departmentName(departmentNameMap.get(store.getDepartmentId()))
-					.rank(rank != null ? rank.intValue() + 1 : 0)
-					.teamsAhead(rank != null ? rank.intValue() : 0)
-					.partySize(partySize != null ? partySize : 0)
-					.status(waitingUserRedisRepository.getWaitingStatus(storeId, userId)) // 필요시 redis에 상태값이 있으면 조회해서 세팅
-					.registeredAt(registeredAt)
-					.location(store.getLocation())
-					.profileImageUrl(customOAuth2User.getUser().getProfileImage())
-					.build());
+		List<Object> pipelineResults = redisTemplate.executePipelined((RedisCallback<Object>)conn -> {
+			byte[] uid = redisTemplate.getStringSerializer().serialize(userId);
+			for (Long storeId : storeIds) {
+				String qk = RedisKeyUtils.buildWaitingKeyPrefix() + storeId;
+				String pk = RedisKeyUtils.buildWaitingPartySizeKeyPrefix() + storeId;
+				String sk = RedisKeyUtils.buildWaitingStatusKeyPrefix() + storeId;
+				String nk = RedisKeyUtils.buildReservationNumberKey(storeId);
+				conn.zRank(qk.getBytes(), uid);      // 순번 (0-based)
+				conn.hGet(pk.getBytes(), uid);       // partySize (String)
+				conn.zScore(qk.getBytes(), uid);     // timestamp (Double)
+				conn.hGet(sk.getBytes(), uid);       // status (String)
+				conn.hGet(nk.getBytes(), uid);       // reservationId (String)
 			}
+			return null;
+		});
+
+		// 4) 결과 매핑
+		List<MyWaitingQueueDto> result = new ArrayList<>(storeIds.size());
+		Iterator<Object> it = pipelineResults.iterator();
+		for (Long storeId : storeIds) {
+			Store store = storeMap.get(storeId);
+			Long rankObj = (Long)it.next(); // null 가능
+			String partyStr = (String)it.next();
+			Double tsScore = (Double)it.next();
+			String status = (String)it.next();
+			String reservationId = (String)it.next();
+
+			int rank = (rankObj != null ? rankObj.intValue() + 1 : 0);
+			int teamsAhead = (rankObj != null ? rankObj.intValue() : 0);
+			int partySize = (partyStr != null ? Integer.parseInt(partyStr) : 0);
+			LocalDateTime registeredAt = tsScore != null
+				? Instant.ofEpochMilli(tsScore.longValue())
+				.atZone(ZoneId.of("Asia/Seoul"))
+				.toLocalDateTime()
+				: null;
+
+			result.add(MyWaitingQueueDto.builder()
+				.reservationId(reservationId)
+				.storeId(storeId)
+				.storeName(store.getName())
+				.departmentName(deptNameMap.get(store.getDepartmentId()))
+				.location(store.getLocation())
+				.profileImageUrl(profileMap.getOrDefault(storeId, ""))
+				.bannerImageUrl(bannerMap.getOrDefault(storeId, Collections.emptyList()))
+				.rank(rank)
+				.teamsAhead(teamsAhead)
+				.partySize(partySize)
+				.status(status)
+				.registeredAt(registeredAt)
+				.build()
+			);
 		}
+
 		return result;
 	}
-
 
 	@Transactional
 	public ReservationCreateResponseDto create(Long storeId, CustomOAuth2User customOAuth2User,

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/entity/Reservation.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/entity/Reservation.java
@@ -35,7 +35,7 @@ public class Reservation {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "reservation_number", nullable = false, length = 50)
+	@Column(name = "reservation_number", nullable = true, length = 50)
 	private String reservationNumber;
 
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/entity/Reservation.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/entity/Reservation.java
@@ -35,6 +35,9 @@ public class Reservation {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(name = "reservation_number", nullable = false, length = 50)
+	private String reservationNumber;
+
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "store_id")
 	private Store store;
@@ -45,6 +48,15 @@ public class Reservation {
 
 	@Column(name = "requested_at", nullable = false)
 	private LocalDateTime requestedAt;
+
+	@Column(name = "called_at", nullable = true)
+	private LocalDateTime calledAt;      // 호출 시각
+
+	@Column(name = "confirmed_at", nullable = true)
+	private LocalDateTime confirmedAt;   // 확정(입장 완료) 시각
+
+	@Column(name = "cancelled_at", nullable = true)
+	private LocalDateTime cancelledAt;   // 취소 시각
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -57,4 +69,19 @@ public class Reservation {
 		this.status = status;
 	}
 
+	// 상태 전환 메서드
+	public void markCalling(LocalDateTime ts) {
+		this.status   = ReservationStatus.CALLING;
+		this.calledAt = ts;
+	}
+
+	public void markConfirmed(LocalDateTime ts) {
+		this.status      = ReservationStatus.CONFIRMED;
+		this.confirmedAt = ts;
+	}
+
+	public void markCancelled(LocalDateTime ts) {
+		this.status      = ReservationStatus.CANCELLED;
+		this.cancelledAt = ts;
+	}
 }

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
@@ -22,8 +22,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	Optional<Reservation> findByStore_StoreIdAndUserIdAndRequestedAtBetween(
 		Long storeId, Long userId, LocalDateTime start, LocalDateTime end);
 
-	Optional<Reservation> findFirstByStore_StoreIdAndUserIdAndRequestedAtBetweenOrderByRequestedAtDesc(
-		Long storeId, Long userId, LocalDateTime start, LocalDateTime end);
+	Optional<Reservation> findFirstByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetweenOrderByRequestedAtDesc(
+		Long storeId, Long userId, List<ReservationStatus> statuses, LocalDateTime start, LocalDateTime end);
 
 	List<Reservation> findAllByStore_StoreIdAndStatusInAndRequestedAtBetween(
 		Long storeId, List<ReservationStatus> statuses, LocalDateTime start, LocalDateTime end);

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/repository/StoreImageRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/repository/StoreImageRepository.java
@@ -1,7 +1,5 @@
 package com.nowait.domaincorerdb.store.repository;
 
-import static com.nowait.domaincorerdb.store.entity.ImageType.*;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -23,5 +21,6 @@ public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
 
 	List<StoreImage> findByStoreAndImageType(Store store, ImageType imageType);
 
+	List<StoreImage> findAllByStore_StoreIdInAndImageTypeIn(List<Long> storeIds, List<ImageType> imageTypes);
 
 }

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/repository/StoreRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/store/repository/StoreRepository.java
@@ -36,4 +36,13 @@ public interface StoreRepository extends JpaRepository<Store, Long>, StoreCustom
 	List<Store> searchByKeywordNative(@Param("kw") String booleanKeyword);
 
 	List<Store> findAllByStoreIdInOrderByStoreIdAsc(List<Long> storeIds);
+
+	@Query(value = """
+		SELECT s
+		  FROM Store s
+		  LEFT JOIN Department d ON s.departmentId = d.id
+		 WHERE s.deleted = false
+		   AND s.storeId IN :ids
+		""")
+	List<Store> findAllWithDepartmentByStoreIdIn(@Param("ids") List<Long> ids);
 }

--- a/nowait-domain/domain-redis/src/main/java/com/nowait/domaincoreredis/common/util/RedisKeyUtils.java
+++ b/nowait-domain/domain-redis/src/main/java/com/nowait/domaincoreredis/common/util/RedisKeyUtils.java
@@ -1,6 +1,10 @@
 package com.nowait.domaincoreredis.common.util;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 
 public class RedisKeyUtils {
 
@@ -18,7 +22,6 @@ public class RedisKeyUtils {
 	private static final String WAITING_PARTYSIZE_KEY_PREFIX = "waiting:party:";
 	private static final String WAITING_STATUS_KEY_PREFIX = "waiting:status:";
 
-
 	private RedisKeyUtils() {
 		throw new UnsupportedOperationException("유틸리티 서비스는 인스턴스화 할 수 없습니다.");
 	}
@@ -35,11 +38,48 @@ public class RedisKeyUtils {
 		return KEY_NEXT;
 	}
 
-	public static String buildMenuKey() { return KEY_FMT; }
+	public static String buildMenuKey() {
+		return KEY_FMT;
+	}
 
-	public static DateTimeFormatter buildMenuDateKey() { return DTF; }
+	public static DateTimeFormatter buildMenuDateKey() {
+		return DTF;
+	}
 
-	public static String buildWaitingKeyPrefix() { return WAITING_KEY_PREFIX; }
-	public static String buildWaitingPartySizeKeyPrefix() { return WAITING_PARTYSIZE_KEY_PREFIX; }
-	public static String buildWaitingStatusKeyPrefix() { return WAITING_STATUS_KEY_PREFIX; }
+	public static String buildWaitingKeyPrefix() {
+		return WAITING_KEY_PREFIX;
+	}
+
+	public static String buildWaitingPartySizeKeyPrefix() {
+		return WAITING_PARTYSIZE_KEY_PREFIX;
+	}
+
+	public static String buildWaitingStatusKeyPrefix() {
+		return WAITING_STATUS_KEY_PREFIX;
+	}
+
+	// Waiting Reservation Number key
+	public static String buildReservationSeqKey(Long storeId) {
+		return String.format("reservation:seq:%d", storeId);
+	}
+
+	public static String buildReservationNumberKey(Long storeId) {
+		return String.format("reservation:number:%d", storeId);
+	}
+
+	/**
+	 * 대기 호출 시각(hash)에 사용할 키 접두사
+	 */
+	public static String buildWaitingCalledAtKeyPrefix() {
+		return "waiting:calledAt:";
+	}
+
+	public static Date expireAtNext03() {
+		ZoneId zone = ZoneId.of("Asia/Seoul");
+		LocalDateTime now = LocalDateTime.now(zone);
+		LocalDateTime next03 = now.toLocalDate().plusDays(1).atTime(3, 0);
+		Instant instant = next03.atZone(zone).toInstant();
+
+		return Date.from(instant);
+	}
 }


### PR DESCRIPTION
## 작업 요약
- 예약 번호 생성 로직 추가
- 기존 로직 개선 
- N + 1 문제 해결
## Issue Link
#174 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예약 대기열에 고유한 예약 번호(reservationNumber)와 호출/확정/취소 시각 정보가 추가되었습니다.
  * 사용자 대기 목록 조회 시 매장 정보, 부서명, 위치, 프로필/배너 이미지, 예약 ID 등 상세 정보가 제공됩니다.
  * 신규 DTO 및 응답 필드가 추가되어 예약 및 대기 상태 정보를 더욱 풍부하게 전달합니다.

* **기능 개선**
  * 대기열 및 예약 관련 데이터 조회가 대량 처리 및 Redis 파이프라인을 통해 더욱 빨라졌습니다.
  * 예약 상태 변경(호출, 확정, 취소) 시 일관된 상태 전환 및 시간 기록이 적용됩니다.
  * API 응답이 표준화된 성공 포맷으로 반환됩니다.
  * Redis 키 만료 시간이 매일 오전 3시 기준으로 조정되어 관리 효율성이 향상되었습니다.
  * Redis 대기열 관리 기능이 개선되어 예약 번호 관리 및 호출 시간 기록이 추가되었습니다.

* **버그 수정**
  * 대기열 삭제 시 관련된 예약 번호 및 호출 시간 정보도 함께 삭제됩니다.

* **기타**
  * 코드 가독성 및 유지보수성을 위한 포맷팅 및 리팩터링이 일부 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->