### PR TITLE
Refactor: 웨이팅 예외처리 추가 및 공통 메서드 추출

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/controller/ReservationController.java
@@ -53,7 +53,7 @@ public class ReservationController {
 		@PathVariable Long storeId,
 		@AuthenticationPrincipal MemberDetails memberDetails
 	) {
-		List<WaitingUserResponse> response = reservationService.getCompletedWaitingUserDetails(storeId);
+		List<WaitingUserResponse> response = reservationService.getCompletedWaitingUserDetails(storeId, memberDetails);
 		return ResponseEntity
 			.ok()
 			.body(

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -236,9 +236,6 @@ public class ReservationService {
 				// 1) 기존 대기 중이거나 호출 중일 때: Redis → DB 최초 저장
 				if (ReservationStatus.WAITING.name().equals(currStatus) || ReservationStatus.CALLING.name().equals(currStatus)) {
 
-					// Redis 전부 삭제
-					waitingRedisRepository.deleteWaiting(storeId, userId);
-
 					// 새 Reservation 생성 & 저장
 					Reservation r = Reservation.builder()
 						.reservationNumber(reservationNumber)
@@ -252,6 +249,8 @@ public class ReservationService {
 					// 호출 시각 반영
 					r.markUpdated(LocalDateTime.now(), ReservationStatus.CONFIRMED);
 					Reservation saved = reservationRepository.save(r);
+					// Redis 전부 삭제
+					waitingRedisRepository.deleteWaiting(storeId, userId);
 					return EntryStatusResponseDto.fromEntity(saved);
 				} else {
 					// 2) 이미 취소(CANCELLED)된 경우: DB 레코드 찾아 바로 CONFIRMED 로 전환
@@ -277,7 +276,6 @@ public class ReservationService {
 					  || ReservationStatus.CALLING.name().equals(currStatus))) {
 					throw new IllegalStateException("WAITING/CALLING 상태에서만 취소 가능합니다.");
 				}
-				waitingRedisRepository.deleteWaiting(storeId, userId);
 
 				Reservation r = Reservation.builder()
 					.reservationNumber(reservationNumber)
@@ -290,6 +288,8 @@ public class ReservationService {
 
 				r.markUpdated(LocalDateTime.now(), ReservationStatus.CANCELLED);
 				Reservation saved = reservationRepository.save(r);
+				waitingRedisRepository.deleteWaiting(storeId, userId);
+
 				return EntryStatusResponseDto.fromEntity(saved);
 
 			default:

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -176,41 +175,17 @@ public class ReservationService {
 
 	// 완료 or 취소 처리된 대기 리스트 조회
 	@Transactional(readOnly = true)
-	public List<WaitingUserResponse> getCompletedWaitingUserDetails(Long storeId) {
-		List<Reservation> reservations = reservationRepository.findAllByStore_StoreIdAndStatusInAndRequestedAtBetween(
-			storeId,
-			List.of(ReservationStatus.CONFIRMED, ReservationStatus.CANCELLED),
-			LocalDate.now().atStartOfDay(),
-			LocalDate.now().atTime(LocalTime.MAX));
+	public List<WaitingUserResponse> getCompletedWaitingUserDetails(Long storeId, MemberDetails memberDetails) {
+		authorize(storeId, memberDetails);
+		List<Reservation> reservations = findTodayWaiting(storeId);
+
+		if (reservations.isEmpty()) {
+			throw new ReservationNotFoundException();
+		}
 
 		return reservations.stream()
-			.map(r -> WaitingUserResponse.fromEntity(r))
+			.map(WaitingUserResponse::fromEntity)
 			.toList();
-	}
-
-	private User authorize(Long storeId, MemberDetails member) {
-		User u = userRepository.findById(member.getId())
-			.orElseThrow(UserNotFoundException::new);
-		if (!Role.SUPER_ADMIN.equals(u.getRole()) && !storeId.equals(u.getStoreId())) {
-			throw new ReservationViewUnauthorizedException();
-		}
-		return u;
-	}
-
-	// 공통: 오늘 날짜 예약 조회
-	private Reservation findTodayReservation(Long storeId, String userId) {
-		LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
-		LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
-
-		return reservationRepository
-			.findByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetween(
-				storeId,
-				Long.valueOf(userId),
-				List.of(ReservationStatus.WAITING, ReservationStatus.CALLING),
-				startOfDay,
-				endOfDay
-			)
-			.orElseThrow(() -> new IllegalArgumentException("오늘 날짜의 예약이 존재하지 않습니다."));
 	}
 
 	/**
@@ -320,6 +295,33 @@ public class ReservationService {
 			default:
 				throw new IllegalArgumentException("지원하지 않는 상태: " + newStatus);
 		}
+	}
+
+
+	/**
+	 * 공통 메서드
+	 */
+	// 오늘 날짜 예약 조회
+	private List<Reservation> findTodayWaiting(Long storeId) {
+		ZoneId zone = ZoneId.of("Asia/Seoul");
+		LocalDate today = LocalDate.now(zone);
+
+		return reservationRepository.findAllByStore_StoreIdAndStatusInAndRequestedAtBetween(
+			storeId,
+			List.of(ReservationStatus.CONFIRMED, ReservationStatus.CANCELLED),
+			today.atStartOfDay(zone).toLocalDateTime(),
+			today.atTime(LocalTime.MAX)
+		);
+	}
+
+	// 사용자 인증
+	private User authorize(Long storeId, MemberDetails member) {
+		User u = userRepository.findById(member.getId())
+			.orElseThrow(UserNotFoundException::new);
+		if (!Role.SUPER_ADMIN.equals(u.getRole()) && !storeId.equals(u.getStoreId())) {
+			throw new ReservationViewUnauthorizedException();
+		}
+		return u;
 	}
 }
 

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
@@ -15,26 +15,12 @@ import com.nowait.domaincorerdb.user.entity.User;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 	List<Reservation> findAllByStore_StoreIdOrderByRequestedAtAsc(Long storeId);
+
 	boolean existsByUserAndStoreAndStatusIn(User user, Store store, List<ReservationStatus> statuses);
-
-	Optional<Reservation> findByStore_StoreIdAndUserId(Long storeId, Long userId);
-
-	Optional<Reservation> findByStore_StoreIdAndUserIdAndRequestedAtBetween(
-		Long storeId, Long userId, LocalDateTime start, LocalDateTime end);
 
 	Optional<Reservation> findFirstByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetweenOrderByRequestedAtDesc(
 		Long storeId, Long userId, List<ReservationStatus> statuses, LocalDateTime start, LocalDateTime end);
 
 	List<Reservation> findAllByStore_StoreIdAndStatusInAndRequestedAtBetween(
 		Long storeId, List<ReservationStatus> statuses, LocalDateTime start, LocalDateTime end);
-	Optional<Reservation> findByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetween(
-		Long storeId,
-		Long userId,
-		List<ReservationStatus> statuses,
-		LocalDateTime start,
-		LocalDateTime end
-	);
-
-	List<Reservation> findAllByStore_StoreId(Long storeId);
-
 }


### PR DESCRIPTION
## 작업 요약
- 웨이팅 목록 없는 경우 예외 처리 추가
- 당일 웨이팅 목록 조회 메서드 분리 
## Issue Link
#192 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 예약 완료 대기 사용자 목록 조회 시 인증된 사용자 정보가 반영되어 접근 권한이 강화되었습니다.
  * 날짜 및 시간대 처리(Asia/Seoul)가 명확해져 오늘 기준의 예약 데이터가 정확하게 조회됩니다.
  * 대기 상태 처리 시 데이터 정합성을 위해 DB 저장 후에만 대기 데이터가 정리됩니다.

* **리팩터링**
  * 사용되지 않는 예약 관련 조회 기능이 제거되어 시스템이 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->