### PR TITLE
refactor(discord): 에러 발생 시간 서울 기준으로 변경

### DIFF
--- a/nowait-infra/src/main/java/com/nowait/discord/service/DiscordAlarmService.java
+++ b/nowait-infra/src/main/java/com/nowait/discord/service/DiscordAlarmService.java
@@ -3,6 +3,7 @@ package com.nowait.discord.service;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,7 +55,7 @@ public class DiscordAlarmService {
 			.embeds(List.of(DiscordMessage.Embed.builder()
 				.title("ℹ️ 에러 정보")
 				.description(
-					"### 🕖 발생 시간\n" + LocalDateTime.now() + "\n" + "### 🔗 요청 URL\n" + createRequestFullPath(request)
+					"### 🕖 발생 시간\n" + LocalDateTime.now(ZoneId.of("Asia/Seoul")) + "\n" + "### 🔗 요청 URL\n" + createRequestFullPath(request)
 					+ "\n" + "### 📄 Stack Trace\n" + "```\n" + getStackTrace(e).substring(0, 1000) + "\n```")
 				.build()))
 			.build();


### PR DESCRIPTION
## 작업 요약
- 에러 발생 시간 서울 기준으로 변경
## Issue Link
#192 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Discord 알림 메시지의 오류 발생 시각이 Asia/Seoul 시간대로 정확하게 표시되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->