### PR TITLE
refactor(storePayment): 결제 데이터 없는 경우 204 반환하도록 변경

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/controller/StorePaymentController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/controller/StorePaymentController.java
@@ -1,5 +1,7 @@
 package com.nowait.applicationuser.storepayment.controller;
 
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,13 +9,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nowait.applicationuser.storepayment.dto.StorePaymentReadDto;
 import com.nowait.applicationuser.storepayment.service.StorePaymentService;
 import com.nowait.common.api.ApiUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,12 +32,25 @@ public class StorePaymentController {
 	@Operation(summary = "주점 결제 정보 조회", description = "주점 ID로 주점 결제 정보를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "주점 결제 정보 조회 성공")
 	public ResponseEntity<?> getStorePaymentByStoreId(@PathVariable Long storeId) {
-		return ResponseEntity
-			.status(HttpStatus.OK)
-			.body(
-				ApiUtils.success(
-					storePaymentService.getStorePaymentByStoreId(storeId)
-				)
-			);
+		Optional<StorePaymentReadDto> response = storePaymentService.getStorePaymentByStoreId(storeId);
+
+		if (response.isPresent()) {
+			return ResponseEntity
+				.status(HttpStatus.OK)
+				.body(
+					ApiUtils.success(
+						response
+					)
+				);
+		} else {
+			return ResponseEntity
+				.status(HttpStatus.NO_CONTENT)
+				.body(
+					ApiUtils.success(
+						response
+					)
+				);
+		}
+
 	}
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentService.java
@@ -1,7 +1,9 @@
 package com.nowait.applicationuser.storepayment.service;
 
+import java.util.Optional;
+
 import com.nowait.applicationuser.storepayment.dto.StorePaymentReadDto;
 
 public interface StorePaymentService {
-	StorePaymentReadDto getStorePaymentByStoreId(Long storeId);
+	Optional<StorePaymentReadDto> getStorePaymentByStoreId(Long storeId);
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentServiceImpl.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentServiceImpl.java
@@ -1,10 +1,10 @@
 package com.nowait.applicationuser.storepayment.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.nowait.applicationuser.storepayment.dto.StorePaymentReadDto;
-import com.nowait.domaincorerdb.store.exception.StoreNotFoundException;
-import com.nowait.domaincorerdb.storepayment.entity.StorePayment;
 import com.nowait.domaincorerdb.storepayment.exception.StorePaymentParamEmptyException;
 import com.nowait.domaincorerdb.storepayment.repository.StorePaymentRepository;
 
@@ -18,12 +18,10 @@ public class StorePaymentServiceImpl implements StorePaymentService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public StorePaymentReadDto getStorePaymentByStoreId(Long storeId) {
+	public Optional<StorePaymentReadDto> getStorePaymentByStoreId(Long storeId) {
 		if (storeId == null) throw new StorePaymentParamEmptyException();
 
-		StorePayment storePayment = storePaymentRepository.findByStoreId(storeId)
-			.orElseThrow(StoreNotFoundException::new);
-
-		return StorePaymentReadDto.fromEntity(storePayment);
+		return storePaymentRepository.findByStoreId(storeId)
+			.map(StorePaymentReadDto::fromEntity);
 	}
 }


### PR DESCRIPTION
## 작업 요약
결제 데이터 없는 경우 204 반환하도록 변경
## Issue Link
#186 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매장 결제 정보 조회 시, 해당 정보가 없을 경우 HTTP 204 NO CONTENT 상태로 응답하도록 개선되었습니다.  
  * 매장 결제 정보가 존재하지 않을 때 더 이상 예외가 발생하지 않고, 빈 결과로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->