### PR TITLE
bug: cGroup v1 마운트 실패로 인한 자바 버전 변경

### DIFF
--- a/nowait-app-admin-api/Dockerfile
+++ b/nowait-app-admin-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17.0.8-jdk
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-admin-api.jar
 

--- a/nowait-app-user-api/Dockerfile
+++ b/nowait-app-user-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17.0.8-jdk
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-user-api.jar
 

--- a/nowait-common/Dockerfile
+++ b/nowait-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17.0.8-jdk
 
 WORKDIR /app
 COPY build/libs/*.jar nowait-common.jar


### PR DESCRIPTION
## 작업 요약
cGroup v1 마운트 실패로 인한 자바 버전 변경
## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Java 런타임 환경을 보다 명확하게 지정하기 위해 Docker 이미지의 기본 버전을 openjdk:17에서 openjdk:17.0.8-jdk로 고정하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->