### PR TITLE
bug: cGroup v1 마운트 실패

### DIFF
--- a/nowait-app-admin-api/Dockerfile
+++ b/nowait-app-admin-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17.0.8-jdk
+FROM openjdk:17
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-admin-api.jar
 

--- a/nowait-app-user-api/Dockerfile
+++ b/nowait-app-user-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17.0.8-jdk
+FROM openjdk:17
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-user-api.jar
 

--- a/nowait-common/Dockerfile
+++ b/nowait-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17.0.8-jdk
+FROM openjdk:17
 
 WORKDIR /app
 COPY build/libs/*.jar nowait-common.jar


### PR DESCRIPTION
## 작업 요약

## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지의 기본 OpenJDK 버전을 고정된 패치 버전에서 최신 OpenJDK 17 버전으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->