### PR TITLE
bug: cGroup v1 마운트 실패

### DIFF
--- a/nowait-app-admin-api/Dockerfile
+++ b/nowait-app-admin-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17-slim
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-admin-api.jar
 

--- a/nowait-app-user-api/Dockerfile
+++ b/nowait-app-user-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17-slim
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-user-api.jar
 

--- a/nowait-common/Dockerfile
+++ b/nowait-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17-slim
 
 WORKDIR /app
 COPY build/libs/*.jar nowait-common.jar


### PR DESCRIPTION
## 작업 요약
- 이미지 자바 slim으로 변경 
## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지가 더 슬림한 openjdk:17-slim 버전으로 변경되어 앱 배포 이미지의 용량이 줄었습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->