### PR TITLE
bug: cGroup v1 마운트 실패로 인한 자바 버전 업그레이드

### DIFF
--- a/nowait-app-admin-api/Dockerfile
+++ b/nowait-app-admin-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM openjdk:21-slim
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-admin-api.jar
 

--- a/nowait-app-user-api/Dockerfile
+++ b/nowait-app-user-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM openjdk:21-slim
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} nowait-app-user-api.jar
 

--- a/nowait-common/Dockerfile
+++ b/nowait-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM openjdk:21-slim
 
 WORKDIR /app
 COPY build/libs/*.jar nowait-common.jar


### PR DESCRIPTION
## 작업 요약
cGroup v1 마운트 실패로 인한 자바 버전 업그레이드
## Issue Link
#243 
## 문제점 및 어려움
EC2 인스턴스 교체 후 도커 이미지 실행 불가 -> 정확한 원인은 모르겠지만 서칭 결과 자바 버전 문제 
## 해결 방안
자바 버전 업그레이드 
## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 서비스의 Docker 이미지가 최신 OpenJDK 21-slim 버전으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->