### PR TITLE
Refoctor: 주문 내역 조회 날짜 필터링 추가

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/controller/OrderController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/controller/OrderController.java
@@ -35,7 +35,7 @@ public class OrderController {
 
 	@GetMapping("/{storeId}")
 	@Operation(summary = "주점별 주문리스트 조회", description = "특정 주점에 대한 예약리스트 조회")
-	@ApiResponse(responseCode = "200", description = "주리스트 조회")
+	@ApiResponse(responseCode = "200", description = "주문 리스트 조회")
 	public ResponseEntity<?> getOrderListByStoreId(@PathVariable Long storeId,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 		List<OrderResponseDto> response = orderService.findAllOrders(storeId, memberDetails);

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/service/OrderService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/service/OrderService.java
@@ -1,6 +1,8 @@
 package com.nowait.applicationadmin.order.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -46,7 +48,11 @@ public class OrderService {
 		if (!Role.SUPER_ADMIN.equals(user.getRole()) && !user.getStoreId().equals(storeId)) {
 			throw new OrderViewUnauthorizedException();
 		}
-		return orderRepository.findAllByStore_StoreId(storeId)
+
+		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+		LocalDateTime startDateTime = today.atStartOfDay();
+		LocalDateTime endDateTime = today.plusDays(1).atStartOfDay();
+		return orderRepository.findAllByStore_StoreIdAndCreatedAtBetween(storeId, startDateTime, endDateTime)
 			.stream()
 			.map(OrderResponseDto::fromEntity)
 			.collect(Collectors.toList());

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/config/security/CorsConfig.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/config/security/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
 		CorsConfiguration config = new CorsConfiguration();
 
 		config.setAllowCredentials(true); // 쿠키나 인증헤더 자격증명 허용
-		config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:63342", "https://nowait-user.vercel.app", "https://nowait.co.kr", "https://www.nowait.co.kr")); // 허용할 출처 설정
+		config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:63342", "https://nowait-user.vercel.app", "https://nowait.co.kr")); // 허용할 출처 설정
 		config.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")); // 메서드 허용
 		config.setAllowedHeaders(List.of("*")); //클라이언트가 보낼 수 있는 헤더
 		config.setExposedHeaders(List.of("Authorization")); //클라이언트(브라우저)가 접근할 수 있는 헤더 지정

--- a/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepository.java
+++ b/nowait-domain/domain-admin-rdb/src/main/java/com/nowait/domainadminrdb/statistic/repository/StatisticCustomRepository.java
@@ -9,8 +9,6 @@ import com.nowait.domainadminrdb.statistic.dto.StoreInfo;
 import com.nowait.domainadminrdb.statistic.dto.StoreSales;
 import com.nowait.domainadminrdb.statistic.dto.TopSalesStoresDetail;
 
-
-
 public interface StatisticCustomRepository {
 
 	OrderSalesSumDetail findSalesSumByStoreId(Long storeId, LocalDate date);
@@ -18,7 +16,6 @@ public interface StatisticCustomRepository {
 	List<TopSalesStoresDetail> getTop4PlusMine(Long storeId);
 
 	Map<Long, Integer> findOrderCountByStoreIds(List<Long> storeIds);
-
 
 	// redis 사용하는 부분
 	List<StoreSales> findTotalSales();

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/order/repository/OrderRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/order/repository/OrderRepository.java
@@ -16,5 +16,5 @@ public interface OrderRepository extends JpaRepository<UserOrder, Long> {
 	List<UserOrder> findByStore_StoreIdAndTableIdAndSessionId(Long storeId, Long tableId, String sessionId);
 
 	@EntityGraph(attributePaths = {"orderItems", "orderItems.menu"})
-	List<UserOrder> findAllByStore_StoreId(Long storeId);
+	List<UserOrder> findAllByStore_StoreIdAndCreatedAtBetween(Long storeId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 }


### PR DESCRIPTION
## 작업 요약
- 주문 내역 조회 날짜 필터링 추가하여 당일 주문내역만 보여주도록 변경 
## Issue Link
#248 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 주문 목록 조회 시 오늘 날짜(Asia/Seoul 기준)에 생성된 주문만 반환하도록 변경되었습니다.
  * 주문 조회 관련 API 문서의 설명이 더 명확하게 수정되었습니다.

* **기타**
  * CORS 허용 도메인에서 "https://www.nowait.co.kr"이 제거되었습니다.
  * 코드 내 불필요한 공백이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->