### PR TITLE
Refoctor: 관리자용 메뉴 이름 추가

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuCreateRequest.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuCreateRequest.java
@@ -16,6 +16,8 @@ public class MenuCreateRequest {
 	@NotNull
 	private Long storeId;
 	@NotNull
+	private String adminDisplayName;
+	@NotNull
 	private String name;
 	@NotNull
 	private String description;
@@ -25,6 +27,7 @@ public class MenuCreateRequest {
 	public Menu toEntity() {
 		return Menu.builder()
 			.storeId(storeId)
+			.adminDisplayName(adminDisplayName != null ? adminDisplayName : name)
 			.name(name)
 			.description(description)
 			.price(price)

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuCreateResponse.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuCreateResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.nowait.domaincorerdb.menu.entity.Menu;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import lombok.Getter;
 public class MenuCreateResponse {
 	private Long menuId;
 	private Long storeId;
+	private String adminDisplayName;
 	private String name;
 	private String description;
 	private Integer price;
@@ -26,6 +28,7 @@ public class MenuCreateResponse {
 			.createdAt(menu.getCreatedAt())
 			.menuId(menu.getId())
 			.storeId(menu.getStoreId())
+			.adminDisplayName(menu.getAdminDisplayName())
 			.name(menu.getName())
 			.description(menu.getDescription())
 			.price(menu.getPrice())

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuReadDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuReadDto.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.nowait.domaincorerdb.menu.entity.Menu;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import lombok.Getter;
 public class MenuReadDto {
 	private Long menuId;
 	private Long storeId;
+	private String adminDisplayName;
 	private String name;
 	private String description;
 	private Integer price;
@@ -25,6 +27,7 @@ public class MenuReadDto {
 		return MenuReadDto.builder()
 			.menuId(menu.getId())
 			.storeId(menu.getStoreId())
+			.adminDisplayName(menu.getAdminDisplayName())
 			.name(menu.getName())
 			.description(menu.getDescription())
 			.price(menu.getPrice())

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuUpdateRequest.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/dto/MenuUpdateRequest.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class MenuUpdateRequest {
+	private String adminDisplayName;
 	private String name;
 	private String description;
 	private Integer price;

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuService.java
@@ -107,6 +107,7 @@ public class MenuService {
 		}
 
 		menu.updateInfo(
+			request.getAdminDisplayName(),
 			request.getName(),
 			request.getDescription(),
 			request.getPrice()

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/entity/Menu.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/entity/Menu.java
@@ -31,7 +31,7 @@ public class Menu extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Long storeId;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private String adminDisplayName;
 
 	@Column(nullable = false)

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/entity/Menu.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/entity/Menu.java
@@ -32,6 +32,9 @@ public class Menu extends BaseTimeEntity {
 	private Long storeId;
 
 	@Column(nullable = false)
+	private String adminDisplayName;
+
+	@Column(nullable = false)
 	private String name;
 
 	@Column(nullable = true)
@@ -47,10 +50,11 @@ public class Menu extends BaseTimeEntity {
 	private Boolean deleted;
 
 
-	public Menu(LocalDateTime createdAt, Long id, Long storeId, String name, String description, Integer price, Boolean isSoldOut, Boolean deleted) {
+	public Menu(LocalDateTime createdAt, Long id, Long storeId, String adminDisplayName, String name, String description, Integer price, Boolean isSoldOut, Boolean deleted) {
 		super(createdAt);
 		this.Id = id;
 		this.storeId = storeId;
+		this.adminDisplayName = adminDisplayName;
 		this.name = name;
 		this.description = description;
 		this.price = price;
@@ -58,7 +62,8 @@ public class Menu extends BaseTimeEntity {
 		this.deleted = deleted != null ? deleted : false;
 	}
 
-	public void updateInfo(String name, String description, Integer price) {
+	public void updateInfo(String adminDisplayName, String name, String description, Integer price) {
+		if (adminDisplayName != null) this.adminDisplayName = adminDisplayName;
 		if (name != null) this.name = name;
 		if (description != null) this.description = description;
 		if (price != null) this.price = price;


### PR DESCRIPTION
## 작업 요약
- 관리자용 메뉴 이름 CRUD 및 DTO 응답 필드 수정
## Issue Link
#250 
## 문제점 및 어려움
어드민 영역 주문 조회 시 관리자 메뉴 이름으로 보여야 되는건지 확인 필요
## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 메뉴에 관리자 전용 표시 이름(adminDisplayName) 필드가 추가되었습니다. 메뉴 생성, 조회, 수정 시 관리자 표시 이름을 별도로 입력하고 확인할 수 있습니다.  
* **버그 수정**
  * 없음  
* **기타**
  * 메뉴 관련 응답 및 요청 데이터에 관리자 표시 이름 정보가 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->