### PR TITLE
Refoctor: admin 전용 메뉴 이름 추가

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/controller/OrderController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/controller/OrderController.java
@@ -34,7 +34,7 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@GetMapping("/{storeId}")
-	@Operation(summary = "주점별 주문리스트 조회", description = "특정 주점에 대한 예약리스트 조회")
+	@Operation(summary = "주점별 주문 리스트 조회", description = "특정 주점에 대한 주문 리스트 조회")
 	@ApiResponse(responseCode = "200", description = "주문 리스트 조회")
 	public ResponseEntity<?> getOrderListByStoreId(@PathVariable Long storeId,
 		@AuthenticationPrincipal MemberDetails memberDetails) {

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/dto/OrderResponseDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/dto/OrderResponseDto.java
@@ -26,13 +26,13 @@ public class OrderResponseDto {
 		Map<String, MenuDetail> menuDetails = new LinkedHashMap<>();
 
 		for (OrderItem item : userOrder.getOrderItems()) {
-			String name = item.getMenu().getName();
+			String displayName = item.getMenu().getAdminDisplayName();
 			int quantity = item.getQuantity();
 			int price = item.getMenu().getPrice(); // 메뉴 단가
 
 			// 메뉴명이 중복되면 수량만 누적
 			// merge 람다함수 활용(해당 key가 있으면 수량 누적, 없으면 새로 생성)
-			menuDetails.merge(name,
+			menuDetails.merge(displayName,
 				new MenuDetail(quantity, price),
 				(oldVal, newVal) -> new MenuDetail(
 					oldVal.getQuantity() + newVal.getQuantity(),

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/user/dto/ManagerLoginResponseDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/user/dto/ManagerLoginResponseDto.java
@@ -17,6 +17,8 @@ public class ManagerLoginResponseDto {
 	private String email;
 	@Schema(description = "닉네임", example = "무한이")
 	private String nickname;
+	@Schema(description = "주점 Id", example = "1")
+	private Long storeId;
 	@Schema(description = "JWT TOKEN", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxNCIsImVtYWlsIjoiYXBpZG9jQGVtYWlsLmNvbSIsInJvbGVzIjpbIk1FTUJFUiJdLCJleHAiOjE3MTIyMjQ5NzV9.SQKtyHmqn2NKzHy4BX7_IgBePO_svEtmz1xbO9ToMz8")
 	private String accessToken;
 
@@ -25,6 +27,7 @@ public class ManagerLoginResponseDto {
 			.userId(user.getId())
 			.email(user.getEmail())
 			.nickname(user.getNickname())
+			.storeId(user.getStoreId())
 			.accessToken(token)
 			.build();
 	}


### PR DESCRIPTION
## 작업 요약
- 주문 조회 시 어드민 메뉴 이름으로 노출되도록 변경
- 로그인 시 response에 storeId 필드 추가
## Issue Link
#250 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 매니저 로그인 응답에 주점 ID(`storeId`) 정보가 추가되었습니다.

* **버그 수정**
  * 주문 응답에서 메뉴 상세 항목이 관리자용 메뉴명 기준으로 그룹화되도록 개선되었습니다.

* **문서**
  * 주문 리스트 조회 관련 API의 설명 문구가 더 명확하게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->