### PR TITLE
refactor: 배포 스크립트 변경

### DIFF
--- a/docker-compose.user.yml
+++ b/docker-compose.user.yml
@@ -8,7 +8,7 @@ services:
       MYSQL_USER: developer
       MYSQL_PASSWORD: gtable1118!
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - mysql_data:/var/lib/mysql
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/ApiAdminApplication.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/ApiAdminApplication.java
@@ -14,4 +14,3 @@ public class ApiAdminApplication {
 		org.springframework.boot.SpringApplication.run(ApiAdminApplication.class, args);
 	}
 }
-

--- a/nowait-app-user-api/src/main/java/com/nowait/ApiUserApplication.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/ApiUserApplication.java
@@ -13,3 +13,4 @@ public class ApiUserApplication {
 		SpringApplication.run(ApiUserApplication.class, args);
 	}
 }
+

--- a/scripts/deploy-admin-docker.sh
+++ b/scripts/deploy-admin-docker.sh
@@ -22,8 +22,8 @@ echo "Cleaning up old containers…"
 docker-compose -f docker-compose.admin.yml -f docker-compose.admin-monitoring.yml -p nowait_dev_admin down
 
 echo "3. start container"
-sudo docker-compose -f docker-compose.admin.yml -f docker-compose.admin-monitoring.yml -p nowait_dev_admin pull nowait-app-admin-api
-sudo docker-compose -f docker-compose.admin.yml -f docker-compose.admin-monitoring.yml -p nowait_dev_admin up -d nowait-app-admin-api
+sudo docker-compose -f docker-compose.admin.yml -f docker-compose.admin-monitoring.yml -p nowait_dev_admin pull nowait-app-admin-api prometheus-admin grafana-admin
+sudo docker-compose -f docker-compose.admin.yml -f docker-compose.admin-monitoring.yml -p nowait_dev_admin up -d nowait-app-admin-api prometheus-admin grafana-admin
 
 echo "4. check container status"
 NEW_CONTAINER_ID=$(docker ps -q --filter "name=nowait-app-admin-api")


### PR DESCRIPTION
## 작업 요약

## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MySQL 서비스의 호스트 포트가 3306에서 3307로 변경되었습니다. 이제 외부에서 MySQL에 접속할 때 3307 포트를 사용해야 합니다.
  * 관리용 배포 스크립트가 업데이트되어 prometheus-admin 및 grafana-admin 컨테이너도 함께 pull 및 시작됩니다.

* **Style**
  * 일부 파일의 불필요한 공백 및 줄바꿈이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->