### PR TITLE
refactor: 기존 storeId publicCode로 변경

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/controller/StorePaymentController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/controller/StorePaymentController.java
@@ -28,11 +28,11 @@ public class StorePaymentController {
 
 	private final StorePaymentService storePaymentService;
 
-	@GetMapping(("/{storeId}"))
+	@GetMapping(("/{publicCode}"))
 	@Operation(summary = "주점 결제 정보 조회", description = "주점 ID로 주점 결제 정보를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "주점 결제 정보 조회 성공")
-	public ResponseEntity<?> getStorePaymentByStoreId(@PathVariable Long storeId) {
-		Optional<StorePaymentReadDto> response = storePaymentService.getStorePaymentByStoreId(storeId);
+	public ResponseEntity<?> getStorePaymentByStoreId(@PathVariable String publicCode) {
+		Optional<StorePaymentReadDto> response = storePaymentService.getStorePaymentByStoreId(publicCode);
 
 		if (response.isPresent()) {
 			return ResponseEntity

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentService.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 import com.nowait.applicationuser.storepayment.dto.StorePaymentReadDto;
 
 public interface StorePaymentService {
-	Optional<StorePaymentReadDto> getStorePaymentByStoreId(Long storeId);
+	Optional<StorePaymentReadDto> getStorePaymentByStoreId(String publicCode);
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentServiceImpl.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/storepayment/service/StorePaymentServiceImpl.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.nowait.applicationuser.storepayment.dto.StorePaymentReadDto;
+import com.nowait.domaincorerdb.store.entity.Store;
+import com.nowait.domaincorerdb.store.exception.StoreNotFoundException;
+import com.nowait.domaincorerdb.store.repository.StoreRepository;
 import com.nowait.domaincorerdb.storepayment.exception.StorePaymentParamEmptyException;
 import com.nowait.domaincorerdb.storepayment.repository.StorePaymentRepository;
 
@@ -15,13 +18,15 @@ import lombok.RequiredArgsConstructor;
 public class StorePaymentServiceImpl implements StorePaymentService {
 
 	private final StorePaymentRepository storePaymentRepository;
+	private final StoreRepository storeRepository;
 
 	@Override
 	@Transactional(readOnly = true)
-	public Optional<StorePaymentReadDto> getStorePaymentByStoreId(Long storeId) {
-		if (storeId == null) throw new StorePaymentParamEmptyException();
-
-		return storePaymentRepository.findByStoreId(storeId)
+	public Optional<StorePaymentReadDto> getStorePaymentByStoreId(String publicCode) {
+		if (publicCode == null) throw new StorePaymentParamEmptyException();
+		Store store = storeRepository.findByPublicCodeAndDeletedFalse(publicCode)
+			.orElseThrow(StoreNotFoundException::new);
+		return storePaymentRepository.findByStoreId(store.getStoreId())
 			.map(StorePaymentReadDto::fromEntity);
 	}
 }


### PR DESCRIPTION
## 작업 요약
기존 storeId publicCode로 변경
## Issue Link
#290 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 매장 결제 조회 API가 경로 파라미터로 숫자형 storeId 대신 문자열 publicCode를 사용하도록 변경되었습니다. 요청 경로가 /{storeId} → /{publicCode}로 바뀌었으며, 클라이언트는 publicCode로 호출해야 합니다.
  * 유효하지 않은 코드에 대해 보다 명확한 오류 응답(예: 404) 제공으로 응답 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->