### PR TITLE
refactor: StoreDetailReadResponse publicCode 필드 추가

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StoreDetailReadResponse.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/store/dto/StoreDetailReadResponse.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 @Builder
 public class StoreDetailReadResponse {
 	private Long storeId;
+	private String publicCode;
 	private Long bookmarkId;
 	private Boolean isBookmark;
 	private Long waitingCount;
@@ -48,6 +49,7 @@ public class StoreDetailReadResponse {
 
 		return StoreDetailReadResponse.builder()
 			.storeId(store.getStoreId())
+			.publicCode(store.getPublicCode())
 			.bookmarkId(bookmarkId)
 			.isBookmark(isBookmark)
 			.waitingCount(waitingCount)


### PR DESCRIPTION
## 작업 요약
- StoreDetailReadResponse publicCode 필드 추가
## Issue Link
#290 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 매장 상세 조회 응답에 공개 코드(publicCode) 필드가 추가되었습니다.
  - 응답에 값이 포함되어 클라이언트에서 매장 공개 코드를 표시·복사·공유할 수 있습니다.
  - 기존 응답은 그대로 유지되며, 신규 필드만 추가로 노출됩니다.
  - 해당 필드를 사용하는 화면(상세/프로필 등)에서 표시 옵션을 활성화할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->