### PR TITLE
refactor: 메뉴 이미지 업로드 로직 리팩토링

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuImageService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuImageService.java
@@ -1,5 +1,7 @@
 package com.nowait.applicationadmin.menu.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,6 +34,13 @@ public class MenuImageService {
 		String type = "menu";
 		Menu menu = menuRepository.findById(menuId)
 			.orElseThrow(MenuNotFoundException::new);
+
+		Optional<MenuImage> existingMenuImage = menuImageRepository.findByMenuId(menuId);
+
+		existingMenuImage.ifPresent(menuImage -> {
+			s3Service.delete(menuImage.getFileKey());
+			menuImageRepository.delete(menuImage);
+		});
 
 		S3Service.S3UploadResult uploadResult = s3Service.upload(type, menuId, file).join();
 

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/repository/MenuImageRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/menu/repository/MenuImageRepository.java
@@ -1,6 +1,7 @@
 package com.nowait.domaincorerdb.menu.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,5 @@ import com.nowait.domaincorerdb.menu.entity.MenuImage;
 @Repository
 public interface MenuImageRepository extends JpaRepository<MenuImage, Long> {
 	List<MenuImage> findByMenu(Menu menu);
+	Optional<MenuImage> findByMenuId(Long menuId);
 }


### PR DESCRIPTION
## 작업 요약
- 메뉴 이미지 재업로드 시 기존 이미지 삭제 후 업로드하도록 변경 
## Issue Link
#300 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 메뉴 이미지 업로드 시 기존 이미지가 자동으로 교체됩니다. 이전 이미지는 백그라운드에서 정리되어 중복 노출이나 혼선을 방지하고, 항상 최신 이미지가 표시됩니다.
  - 관리자 및 사용자 화면에서 메뉴 이미지 일관성이 향상되어 편의성과 신뢰성이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->