### PR TITLE
refactor: 토큰 재발급 로직 수정

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/dto/NewAccessTokenResponse.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/token/dto/NewAccessTokenResponse.java
@@ -1,0 +1,15 @@
+package com.nowait.applicationuser.token.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@Getter
+@ToString(exclude = {"accessToken"}) // 로깅 시 토큰 노출 방지
+public class NewAccessTokenResponse {
+    @JsonProperty("access_token")
+    private final String accessToken;
+}

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/user/controller/UserController.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/user/controller/UserController.java
@@ -2,7 +2,6 @@ package com.nowait.applicationuser.user.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,10 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nowait.applicationuser.token.dto.AuthenticationResponse;
+import com.nowait.applicationuser.token.dto.NewAccessTokenResponse;
 import com.nowait.applicationuser.user.dto.UserUpdateRequest;
 import com.nowait.applicationuser.user.service.UserService;
 import com.nowait.common.api.ApiUtils;
-import com.nowait.domainuserrdb.oauth.dto.CustomOAuth2User;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,21 +26,16 @@ public class UserController {
 
 	@PutMapping("/optional-info")
 	public ResponseEntity<?> putOptional(
-		@CookieValue(value = "refreshToken", required = false) String refreshToken,
 		@Valid @RequestBody UserUpdateRequest req) {
 
-		if (refreshToken == null) {
-			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("accessToken not found in cookies");
-		}
-
-		AuthenticationResponse authenticationResponse = userService.putOptional(refreshToken, req.phoneNumber(),
-			Boolean.TRUE.equals(req.consent()));
+		NewAccessTokenResponse newAccessTokenResponse = userService.putOptional(req.phoneNumber(),
+			Boolean.TRUE.equals(req.consent()), req.accessToken());
 
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(
 				ApiUtils.success(
-					authenticationResponse
+					newAccessTokenResponse
 				)
 			);
 	}

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/user/dto/UserUpdateRequest.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/user/dto/UserUpdateRequest.java
@@ -7,4 +7,5 @@ public record UserUpdateRequest(
 	@NotBlank
 	@Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "휴대폰 번호는 010-0000-0000 형식이어야 합니다.")
 	String phoneNumber,
-	boolean consent) { }
+	boolean consent,
+	String accessToken) { }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/user/service/UserService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/user/service/UserService.java
@@ -2,14 +2,12 @@ package com.nowait.applicationuser.user.service;
 
 import java.time.LocalDateTime;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nowait.applicationuser.security.jwt.JwtUtil;
 import com.nowait.applicationuser.token.dto.AuthenticationResponse;
+import com.nowait.applicationuser.token.dto.NewAccessTokenResponse;
 import com.nowait.applicationuser.token.service.TokenService;
 import com.nowait.domaincorerdb.user.entity.User;
 import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
@@ -26,10 +24,10 @@ public class UserService {
 	private final JwtUtil jwtUtil;
 
 	@Transactional
-	public AuthenticationResponse putOptional(String refreshToken, String phoneNumber, boolean consent) {
+	public NewAccessTokenResponse putOptional(String phoneNumber, boolean consent, String accessToken) {
 
-		Long userId = jwtUtil.getUserId(refreshToken);;
-		String role = jwtUtil.getRole(refreshToken);
+		Long userId = jwtUtil.getUserId(accessToken);;
+		String role = jwtUtil.getRole(accessToken);
 		AuthenticationResponse authenticationResponse;
 
 		User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
@@ -49,16 +47,9 @@ public class UserService {
 			Boolean.TRUE.equals(user.getIsMarketingAgree()),
 			60 * 60 * 1000L
 		);
-		String newRefreshToken = jwtUtil.createRefreshToken(
-			"refreshToken",
-			userId,
-			60 * 60 * 1000L
-		);
 
-		tokenService.updateRefreshToken(userId, refreshToken, newRefreshToken);
+		NewAccessTokenResponse newAccessTokenResponse = new NewAccessTokenResponse(newAccessToken);
 
-		authenticationResponse = new AuthenticationResponse(newAccessToken, newRefreshToken);
-
-		return authenticationResponse;
+		return newAccessTokenResponse;
 	}
 }


### PR DESCRIPTION
## 작업 요약
토큰 재발급 로직 수정
## Issue Link
#310 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자 정보(전화번호/마케팅 동의) 업데이트 후 새로운 액세스 토큰을 즉시 반환합니다.
- 리팩터링
  - 쿠키 기반 리프레시 토큰 흐름을 제거하고, 요청 본문에 포함된 액세스 토큰을 사용하도록 변경했습니다.
  - 사용자 정보 업데이트 요청에 accessToken 필드가 추가되었습니다.
  - 응답 형식이 변경되어 업데이트 성공 시 새 액세스 토큰을 담아 반환합니다.
- 변경 사항 안내
  - 이 업데이트로 기존 쿠키 의존 호출은 동작이 달라질 수 있으니, 요청 본문에 액세스 토큰을 포함하도록 클라이언트를 업데이트하세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->