### PR TITLE
refactor: Reservation status 초기값 추가

### DIFF
--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -286,6 +286,7 @@ public class ReservationService {
 						.partySize(partySize)
 						.requestedAt(requestedAt)
 						.updatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+						.status(ReservationStatus.valueOf(currStatus))
 						.build();
 
 					// 호출 시각 반영
@@ -344,6 +345,7 @@ public class ReservationService {
 					.partySize(partySize)
 					.requestedAt(requestedAt)
 					.updatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+					.status(ReservationStatus.valueOf(currStatus))
 					.build();
 
 				r.markUpdated(LocalDateTime.now(), ReservationStatus.CANCELLED);


### PR DESCRIPTION
## 작업 요약
- Reservation status 초기값 추가
## Issue Link
#319 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 입장 처리 과정에서 예약 상태가 비어 있거나 기본값으로 저장되어 화면에 잘못 표시되던 문제를 수정했습니다.
  - 대기/호출 단계의 예약이 확정·취소로 전환될 때 기존 대기열 상태가 정확히 반영되도록 저장 로직을 보강했습니다.
  - 앱 및 관리자 화면의 예약 목록/상세의 상태 표시와 상태별 필터·통계가 더 일관되고 신뢰성 있게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->