### PR TITLE
fix(user,admin): n+1해결 및 getUser 로직 변경

### DIFF
--- a/nowait-app-admin-api/build.gradle
+++ b/nowait-app-admin-api/build.gradle
@@ -12,6 +12,7 @@ bootJar {
 group = 'com.nowait'
 version = '0.0.1-SNAPSHOT'
 
+
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
@@ -29,11 +30,11 @@ dependencyManagement {
 
 dependencies {
     implementation project(':nowait-common')
-    implementation project(':nowait-infra')
+    implementation project(':nowait-infra')           // 사용자 관련 도메인
     implementation project(':nowait-domain:domain-admin-rdb')
     implementation project(':nowait-domain:domain-core-rdb')
     implementation project(':nowait-domain:domain-redis')
-    implementation project(':nowait-event')
+    implementation project(":nowait-event")
 
     // Spring Boot Starter
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -42,22 +43,26 @@ dependencies {
     // SPRING SECURITY
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-    // redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-    // SWAGGER
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    // OAUTH2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // SWAGGER
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // 디스코드 웹훅
     implementation 'com.github.napstr:logback-discord-appender:1.0.0'
@@ -78,10 +83,12 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation platform("org.testcontainers:testcontainers-bom:1.20.1")
-    testImplementation "org.testcontainers:junit-jupiter"
-    testImplementation "org.testcontainers:testcontainers"
-
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'com.redis:testcontainers-redis:2.2.4'
 }
 
 test {

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/menu/service/MenuService.java
@@ -47,7 +47,7 @@ public class MenuService {
 	@Transactional
 	public MenuCreateResponse createMenu(MenuCreateRequest request, MemberDetails memberDetails) {
 		// 사용자 정보 가져오기
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		// 사용자 역할이 SUPER_ADMIN이거나, storeId가 일치하는지 확인
 		validateViewAuthorization(user, request.getStoreId());
 
@@ -61,7 +61,7 @@ public class MenuService {
 	@Transactional(readOnly = true)
 	public MenuReadResponse getAllMenusByStoreId(Long storeId, MemberDetails memberDetails) {
 		// 사용자 정보 가져오기
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		// 사용자 역할이 SUPER_ADMIN이거나, storeId가 일치하는지 확인
 		validateViewAuthorization(user, storeId);
 
@@ -86,7 +86,7 @@ public class MenuService {
 			throw new MenuParamEmptyException();
 		}
 		// 사용자 정보 가져오기
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Menu menu = getMenu(menuId);
 		// 사용자 역할이 SUPER_ADMIN이거나, storeId가 일치하는지 확인
 		validateViewAuthorization(user, menu.getStoreId());
@@ -102,7 +102,7 @@ public class MenuService {
 
 	@Transactional
 	public MenuReadDto updateMenu(Long menuId, MenuUpdateRequest request, MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Menu menu = getMenu(menuId);
 
 		validateUpdateAuthorization(user, menu.getStoreId());
@@ -168,7 +168,7 @@ public class MenuService {
 
 	@Transactional
 	public String deleteMenu(Long menuId, MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Menu menu = getMenu(menuId);
 
 		validateDeleteAuthorization(user, menu.getStoreId());
@@ -210,9 +210,9 @@ public class MenuService {
 		}
 	}
 
-	private User getUser(MemberDetails memberDetails) {
-		return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
-	}
+	// private User getUser(MemberDetails memberDetails) {
+	// 	return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
+	// }
 
 	private Menu getMenu(Long menuId) {
 		return menuRepository.findByIdAndDeletedFalse(menuId)

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/service/OrderService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/order/service/OrderService.java
@@ -34,9 +34,11 @@ import com.nowait.nowaitevent.order.event.CookingCompleteEvent;
 import com.nowait.nowaitevent.order.event.OrderCancelledEvent;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OrderService {
 	private final OrderRepository orderRepository;
 	private final StatisticCustomRepository statisticCustomRepository;
@@ -46,24 +48,29 @@ public class OrderService {
 
 	@Transactional(readOnly = true)
 	public List<OrderResponseDto> findAllOrders(Long storeId, MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		log.info("getUser 호출 전");
+		User user = memberDetails.getUser();
+		log.info("getUser 호출 완료");
 		storeRepository.findByStoreIdAndDeletedFalse(storeId).orElseThrow(StoreNotFoundException::new);
+		log.info("Store 조회 완료");
 
 		validateViewAuthorization(user, storeId);
 
 		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 		LocalDateTime startDateTime = today.atStartOfDay();
 		LocalDateTime endDateTime = today.plusDays(1).atStartOfDay();
-		return orderRepository.findAllByStore_StoreIdAndCreatedAtBetween(storeId, startDateTime, endDateTime)
+		List<OrderResponseDto> order = orderRepository.findAllByStore_StoreIdAndCreatedAtBetween(storeId, startDateTime, endDateTime)
 			.stream()
 			.map(OrderResponseDto::fromEntity)
 			.collect(Collectors.toList());
+		log.info("Order 조회 완료");
+		return order;
 	}
 
 	@Transactional
 	public OrderStatusUpdateResponseDto updateOrderStatus(Long orderId, OrderStatus newStatus,
 		MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		UserOrder userOrder = orderRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
 		Long storeId = userOrder.getStore().getStoreId();
 
@@ -92,7 +99,7 @@ public class OrderService {
 
 	@Transactional
 	public OrderStatusUpdateResponseDto cancelOrder(Long orderId, CancelOrderRequest cancelOrderRequest, MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		UserOrder userOrder = orderRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
 
 		validateUpdateAuthorization(user, userOrder.getStore().getStoreId());
@@ -113,7 +120,7 @@ public class OrderService {
 
 	@Transactional(readOnly = true)
 	public OrderSalesSumDetail getSaleSumByStoreId(MemberDetails memberDetails, LocalDate date) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Long storeId = user.getStoreId();
 
 		validateViewAuthorization(user, storeId);
@@ -124,7 +131,7 @@ public class OrderService {
 	// 현재는 사용하지 않음. 향후 관리자 통계 페이지 확장 시 활용 가능
 	@Transactional(readOnly = true)
 	public List<TopSalesStoresDetail> getTop5StoresBySalesToday(MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Long storeId = user.getStoreId();
 
 		validateUpdateAuthorization(user, storeId);
@@ -146,10 +153,11 @@ public class OrderService {
 		}
 	}
 
-	private User getUser(MemberDetails memberDetails) {
-		if (memberDetails == null) {
-			throw new OrderViewUnauthorizedException();
-		}
-		return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
-	}
+	// private User getUser(MemberDetails memberDetails) {
+	// 	if (memberDetails == null) {
+	// 		throw new OrderViewUnauthorizedException();
+	// 	}
+	// 	// findById로 Select 쿼리 나가는 것을 getReferenceById로 변경하여 방지
+	// 	return userRepository.getReferenceById(memberDetails.getId());
+	// }
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/reservation/service/ReservationService.java
@@ -61,7 +61,7 @@ public class ReservationService {
 	//TODO 성능 비교를 위해 남겨둔 로직
 	@Transactional(readOnly = true)
 	public ReservationStatusSummaryDto getReservationListByStoreId(Long storeId, MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		validateViewAuthorization(user, storeId);
 		List<Reservation> reservations = reservationRepository.findAllByStore_StoreIdOrderByRequestedAtAsc(storeId);
 
@@ -96,7 +96,7 @@ public class ReservationService {
 	@Transactional
 	public CallGetResponseDto updateReservationStatus(Long reservationId, ReservationStatusUpdateRequestDto requestDto,
 		MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(ReservationNotFoundException::new);
 		validateUpdateAuthorization(user, reservation.getStore().getStoreId());
@@ -195,7 +195,7 @@ public class ReservationService {
 	// 완료 or 취소 처리된 대기 리스트 조회
 	@Transactional(readOnly = true)
 	public List<WaitingUserResponse> getCompletedWaitingUserDetails(Long storeId, MemberDetails memberDetails) {
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		validateViewAuthorization(user, storeId);
 		List<Reservation> reservations = findTodayWaiting(storeId);
 
@@ -214,7 +214,7 @@ public class ReservationService {
 	public EntryStatusResponseDto processEntryStatus(Long storeId, String userId, MemberDetails member,
 		ReservationStatus newStatus) {
 
-		User user = getUser(member);
+		User user = member.getUser();
 		validateUpdateAuthorization(user, storeId);
 
 		if (userId == null || userId.isBlank()) {
@@ -364,7 +364,7 @@ public class ReservationService {
 	public EntryStatusResponseDto processEntryStatusByReservationNumber(Long storeId, String reservationNumber,
 		MemberDetails member, ReservationStatus newStatus) {
 
-		User user = getUser(member);
+		User user = member.getUser();
 		validateUpdateAuthorization(user, storeId);
 
 		if (reservationNumber == null || reservationNumber.isBlank()) {
@@ -542,11 +542,11 @@ public class ReservationService {
 		}
 	}
 
-	private User getUser(MemberDetails memberDetails) {
-		if (memberDetails == null) {
-			throw new ReservationViewUnauthorizedException();
-		}
-		return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
-	}
+	// private User getUser(MemberDetails memberDetails) {
+	// 	if (memberDetails == null) {
+	// 		throw new ReservationViewUnauthorizedException();
+	// 	}
+	// 	return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
+	// }
 }
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/service/StoreServiceImpl.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/store/service/StoreServiceImpl.java
@@ -59,7 +59,7 @@ public class StoreServiceImpl implements StoreService {
 	@Transactional(readOnly = true)
 	public StoreDetailReadResponse getStoreByStoreId(Long storeId, MemberDetails memberDetails) {
 		if (storeId == null) throw new StoreParamEmptyException();
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		validateViewAuthorization(user, storeId);
 
 		Store store = storeRepository.findByStoreIdAndDeletedFalse(storeId)
@@ -82,7 +82,7 @@ public class StoreServiceImpl implements StoreService {
 	public StoreReadDto updateStore(Long storeId, StoreUpdateRequest request, MemberDetails memberDetails) {
 		if (storeId == null || request == null) throw new StoreParamEmptyException();
 
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		validateUpdateAuthorization(user, storeId);
 
 		Store store = storeRepository.findByStoreIdAndDeletedFalse(storeId)
@@ -115,7 +115,7 @@ public class StoreServiceImpl implements StoreService {
 			throw new StoreParamEmptyException();
 		}
 
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		validateUpdateAuthorization(user, storeId);
 
 		Store store = storeRepository.findByStoreIdAndDeletedFalse(storeId)
@@ -150,10 +150,10 @@ public class StoreServiceImpl implements StoreService {
 		}
 	}
 
-	private User getUser(MemberDetails memberDetails) {
-		if (memberDetails == null) {
-			throw new StoreViewUnauthorizedException();
-		}
-		return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
-	}
+	// private User getUser(MemberDetails memberDetails) {
+	// 	if (memberDetails == null) {
+	// 		throw new StoreViewUnauthorizedException();
+	// 	}
+	// 	return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
+	// }
 }

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/storePayment/controller/StorePaymentController.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/storePayment/controller/StorePaymentController.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,11 +12,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nowait.applicationadmin.storePayment.service.StorePaymentService;
 import com.nowait.applicationadmin.storepayment.dto.StorePaymentCreateRequest;
 import com.nowait.applicationadmin.storepayment.dto.StorePaymentCreateResponse;
 import com.nowait.applicationadmin.storepayment.dto.StorePaymentReadDto;
 import com.nowait.applicationadmin.storepayment.dto.StorePaymentUpdateRequest;
-import com.nowait.applicationadmin.storepayment.service.StorePaymentService;
 import com.nowait.common.api.ApiUtils;
 import com.nowait.domaincorerdb.user.entity.MemberDetails;
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/storePayment/service/StorePaymentService.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/storePayment/service/StorePaymentService.java
@@ -1,4 +1,4 @@
-package com.nowait.applicationadmin.storepayment.service;
+package com.nowait.applicationadmin.storePayment.service;
 
 import java.util.Optional;
 

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/storePayment/service/StorePaymentServiceImpl.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/storePayment/service/StorePaymentServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.nowait.applicationadmin.storePayment.service.StorePaymentService;
 import com.nowait.applicationadmin.storepayment.dto.StorePaymentCreateRequest;
 import com.nowait.applicationadmin.storepayment.dto.StorePaymentCreateResponse;
 import com.nowait.applicationadmin.storepayment.dto.StorePaymentReadDto;
@@ -21,7 +22,6 @@ import com.nowait.domaincorerdb.storepayment.exception.StorePaymentViewUnauthori
 import com.nowait.domaincorerdb.storepayment.repository.StorePaymentRepository;
 import com.nowait.domaincorerdb.user.entity.MemberDetails;
 import com.nowait.domaincorerdb.user.entity.User;
-import com.nowait.domaincorerdb.user.exception.UserNotFoundException;
 import com.nowait.domaincorerdb.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -38,7 +38,7 @@ public class StorePaymentServiceImpl implements StorePaymentService {
 	public StorePaymentCreateResponse createStorePayment(StorePaymentCreateRequest request, MemberDetails memberDetails) {
 		if (request == null) throw new StorePaymentParamEmptyException();
 
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Long storeId = user.getStoreId();
 		if (storePaymentRepository.findByStoreId(storeId).isPresent()) {
 			throw new StorePaymentAlreadyExistsException();
@@ -56,7 +56,7 @@ public class StorePaymentServiceImpl implements StorePaymentService {
 	public Optional<StorePaymentReadDto> getStorePaymentByStoreId(MemberDetails memberDetails) {
 		if (memberDetails == null) throw new StorePaymentParamEmptyException();
 
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Long storeId = user.getStoreId();
 		validateViewAuthorization(user, storeId);
 
@@ -69,7 +69,7 @@ public class StorePaymentServiceImpl implements StorePaymentService {
 	public StorePaymentReadDto updateStorePayment(StorePaymentUpdateRequest request, MemberDetails memberDetails) {
 		if (request == null) throw new StorePaymentParamEmptyException();
 
-		User user = getUser(memberDetails);
+		User user = memberDetails.getUser();
 		Long storeId = user.getStoreId();
 		validateUpdateAuthorization(user, storeId);
 		StorePayment storePayment = storePaymentRepository.findByStoreId(storeId)
@@ -86,9 +86,9 @@ public class StorePaymentServiceImpl implements StorePaymentService {
 		return StorePaymentReadDto.fromEntity(storePayment);
 	}
 
-	private User getUser(MemberDetails memberDetails) {
-		return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
-	}
+	// private User getUser(MemberDetails memberDetails) {
+	// 	return userRepository.findById(memberDetails.getId()).orElseThrow(UserNotFoundException::new);
+	// }
 
 	private void validateViewAuthorization(User user, Long storeId) {
 		if (!(Role.SUPER_ADMIN.equals(user.getRole()) || user.getStoreId().equals(storeId))) {

--- a/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/user/dto/ManagerSignupRequestDto.java
+++ b/nowait-app-admin-api/src/main/java/com/nowait/applicationadmin/user/dto/ManagerSignupRequestDto.java
@@ -36,15 +36,23 @@ public class ManagerSignupRequestDto {
 	@Schema(description = "로그인타입", example = "LOCAL")
 	private String socialType;
 
+	@Schema(description = "마케팅 수신 동의", example = "true")
+	private boolean isMarketingAgree;
+
+	@Schema(description = "폰 번호 입력 여부", example = "true")
+	private boolean phoneEntered;
 
 	public User toEntity() {
 		return User.builder()
+			.profileImage("no")
 			.email(email)
 			.phoneNumber("")
 			.password(password)
 			.nickname(nickname)
 			.socialType(SocialType.LOCAL)
 			.role(Role.MANAGER)
+			.isMarketingAgree(isMarketingAgree)
+			.phoneEntered(false)
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.build();

--- a/nowait-app-user-api/build.gradle
+++ b/nowait-app-user-api/build.gradle
@@ -30,9 +30,8 @@ dependencyManagement {
 dependencies {
     implementation project(":nowait-common")
     implementation project(":nowait-domain:domain-core-rdb")
-    implementation project(":nowait-domain:domain-user-rdb") // ✅ 이 줄 꼭 있어야 합니다
+    implementation project(":nowait-domain:domain-user-rdb")
     implementation project(":nowait-domain:domain-redis")
-    implementation project(":nowait-event")
     implementation project(":nowait-infra")
 
     // Spring Boot Starter

--- a/nowait-app-user-api/build.gradle
+++ b/nowait-app-user-api/build.gradle
@@ -12,7 +12,6 @@ bootJar {
 group = 'com.nowait'
 version = '0.0.1-SNAPSHOT'
 
-
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
@@ -29,11 +28,12 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation project(':nowait-common')
-    implementation project(':nowait-infra')           // 사용자 관련 도메인
-    implementation project(':nowait-domain:domain-user-rdb')
-    implementation project(':nowait-domain:domain-core-rdb')
-    implementation project(':nowait-domain:domain-redis')
+    implementation project(":nowait-common")
+    implementation project(":nowait-domain:domain-core-rdb")
+    implementation project(":nowait-domain:domain-user-rdb") // ✅ 이 줄 꼭 있어야 합니다
+    implementation project(":nowait-domain:domain-redis")
+    implementation project(":nowait-event")
+    implementation project(":nowait-infra")
 
     // Spring Boot Starter
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -42,26 +42,22 @@ dependencies {
     // SPRING SECURITY
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-    // OAUTH2
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
-
-    // DB
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // SWAGGER
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
-    // Redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // DB
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // 디스코드 웹훅
     implementation 'com.github.napstr:logback-discord-appender:1.0.0'
@@ -75,19 +71,17 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // actuator
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	// prometheus
+    // prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.mockito:mockito-junit-jupiter'
-    testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'com.redis:testcontainers-redis:2.2.4'
+    testImplementation platform("org.testcontainers:testcontainers-bom:1.20.1")
+    testImplementation "org.testcontainers:junit-jupiter"
+    testImplementation "org.testcontainers:testcontainers"
+
 }
 
 test {

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/order/repository/OrderRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/order/repository/OrderRepository.java
@@ -13,6 +13,7 @@ import com.nowait.domaincorerdb.order.entity.UserOrder;
 public interface OrderRepository extends JpaRepository<UserOrder, Long> {
 	boolean existsBySignatureAndCreatedAtAfter(String signature, LocalDateTime createdAt);
 
+	@EntityGraph(attributePaths = {"store", "orderItems", "orderItems.menu"})
 	List<UserOrder> findByStore_PublicCodeAndTableIdAndSessionId(String publicCode, Long tableId, String sessionId);
 
 	@EntityGraph(attributePaths = {"orderItems", "orderItems.menu"})

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/user/entity/MemberDetails.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/user/entity/MemberDetails.java
@@ -16,6 +16,7 @@ public class MemberDetails implements UserDetails {
 	private final String email;
 	private final String password;
 	private final Collection<? extends GrantedAuthority> authorities;
+	private final User user;
 
 	public static MemberDetails create(User user) {
 		return MemberDetails.builder()
@@ -23,7 +24,12 @@ public class MemberDetails implements UserDetails {
 			.email(user.getEmail())
 			.password(user.getPassword())
 			.authorities(List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())))
+			.user(user)
 			.build();
+	}
+
+	public User getUser() {
+		return user;
 	}
 
 	public Long getId() { return id; }


### PR DESCRIPTION
## 작업 요약
- 사용자 주문 조회 시 n+1 문제 해결(@EntityGraph)
- getuser 로직으로 인한 user 2회 중복 조회 로직 1회 수정으로 변경

## Issue Link
#331 

## 문제점 및 어려움
- user 조회 시 getUser 로직으로 인한 userRepository를 2번 I/O하는 로직 수정

## 해결 방안
- memberDetail에 getuser 로직 추가하여 이 로직으로 대체
memberDetail이 이미 Spring security에서 user 정보를 세션에 저장 후 userRepository와 비교하기 떄문에 굳이 중복할 필요 없다고 판단
## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 매니저 회원가입에 마케팅 동의(isMarketingAgree) 및 휴대폰 입력 상태(phoneEntered) 수집 추가
  * OAuth2 인증 지원 추가

* **개선 사항**
  * 매니저 회원가입 시 프로필 이미지 기본값("no") 설정
  * 주문 조회 관련 연관 데이터 선로딩으로 조회 성능 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->