### PR TITLE
bug: 웨이팅 취소 시 DB 먼저 조회하고 Redis 데이터 삭제하도록 로직 변경

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/reservation/service/ReservationService.java
@@ -1,5 +1,7 @@
 package com.nowait.applicationuser.reservation.service;
 
+import static com.nowait.common.exception.ErrorMessage.*;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -215,38 +217,42 @@ public class ReservationService {
 
 	public boolean cancelWaiting(Long storeId, CustomOAuth2User customOAuth2User) {
 		String userId = customOAuth2User.getUserId().toString();
-		if (storeId == null || userId.trim().isEmpty()) {
-			throw new IllegalArgumentException("Invalid storeId or userId");
+		if (storeId == null) {
+			throw new StoreNotFoundException();
+		}
+
+		if (userId.trim().isEmpty()) {
+			throw new UserNotFoundException();
 		}
 
 		String reservationNumber = waitingUserRedisRepository.getReservationId(storeId, userId);
 		if (reservationNumber == null) {
-			throw new IllegalArgumentException("Waiting not found");
+			throw new ReservationNotFoundException();
 		}
 		Integer partySize = waitingUserRedisRepository.getPartySize(storeId, userId);
 		Long ts = waitingUserRedisRepository.getWaitingTimestamp(storeId, userId);
 
+
 		// 대기열에서 제거 및 결과 반환
-		boolean removed = waitingUserRedisRepository.removeWaiting(storeId, userId);
-		if (!removed) {
-			throw new IllegalArgumentException("Waiting not found");
+		if (reservationRepository.existsReservationByReservationNumber(reservationNumber)) {
+			Reservation reservation = Reservation.builder()
+				.reservationNumber(reservationNumber)
+				.partySize(partySize)
+				.status(ReservationStatus.CANCELLED)
+				.store(storeRepository.getReferenceById(storeId))
+				.user(userRepository.getReferenceById(Long.parseLong(userId)))
+				.updatedAt(LocalDateTime.now())
+				.requestedAt(ts != null ? LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId.of("Asia/Seoul"))
+					: LocalDateTime.now())
+				.build();
+
+			reservationRepository.save(reservation);
 		}
 
-		Reservation reservation = Reservation.builder()
-			.reservationNumber(reservationNumber)
-			.partySize(partySize)
-			.status(ReservationStatus.CANCELLED)
-			.store(storeRepository.getReferenceById(storeId))
-			.user(userRepository.getReferenceById(Long.parseLong(userId)))
-			.updatedAt(LocalDateTime.now())
-			.requestedAt(ts != null ? LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId.of("Asia/Seoul"))
-				: LocalDateTime.now())
-			.build();
-
-		reservationRepository.save(reservation);
+		waitingUserRedisRepository.removeWaiting(storeId, userId);
 		waitingPermitLuaRepository.removeActiveMember(userId, String.valueOf(storeId), reservationNumber);
+
 		return true;
-		// return removed;
 	}
 
 	//TODO 성능 개선 필요

--- a/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
+++ b/nowait-domain/domain-core-rdb/src/main/java/com/nowait/domaincorerdb/reservation/repository/ReservationRepository.java
@@ -18,6 +18,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
 	boolean existsByUserAndStoreAndStatusIn(User user, Store store, List<ReservationStatus> statuses);
 
+	boolean existsReservationByReservationNumber(String reservationNumber);
+
 	Optional<Reservation> findFirstByStore_StoreIdAndUserIdAndStatusInAndRequestedAtBetweenOrderByRequestedAtDesc(
 		Long storeId, Long userId, List<ReservationStatus> statuses, LocalDateTime start, LocalDateTime end);
 


### PR DESCRIPTION
## 작업 요약
웨이팅 취소 시 DB 먼저 조회하고 Redis 데이터 삭제하도록 로직 변경
## Issue Link
#342 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 예약 취소 시 오류 검증 개선 - 더 정확한 예외 처리로 문제 상황 파악 용이

* **개선**
  * 예약 상태 관리 강화 - 취소된 예약 정보를 명시적으로 기록하여 데이터 신뢰성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->