### PR TITLE
refactor:  ReservationNotFoundException 터지는 경우 멱등키 롤백 로직 추가

### DIFF
--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/waiting/redis/WaitingIdempotencyRepository.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/waiting/redis/WaitingIdempotencyRepository.java
@@ -85,4 +85,8 @@ public class WaitingIdempotencyRepository {
 			throw new IllegalArgumentException("Failed to serialize value for Redis", e);
 		}
 	}
+
+	public void deleteByRegisterKey(String key) {
+		redisTemplate.delete(key);
+	}
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/waiting/service/IdempotencyService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/waiting/service/IdempotencyService.java
@@ -48,4 +48,11 @@ public class IdempotencyService {
 		}
 	}
 
+	public void rollbackIdempotencyKey(String idempotentKey) {
+		if (idempotentKey != null && !idempotentKey.isBlank()) {
+			log.info("Rolling back idempotency key: {}", idempotentKey);
+			waitingIdempotencyRepository.deleteByRegisterKey(idempotentKey);
+		}
+	}
+
 }

--- a/nowait-app-user-api/src/main/java/com/nowait/applicationuser/waiting/service/WaitingService.java
+++ b/nowait-app-user-api/src/main/java/com/nowait/applicationuser/waiting/service/WaitingService.java
@@ -142,13 +142,20 @@ public class WaitingService {
 			.orElseThrow(UserNotFoundException::new);
 
 		// DB 웨이팅 상태 취소 처리
-		Reservation reservation = reservationRepository.findReservationByReservationNumber(request.getWaitingNumber())
-			.orElseThrow(ReservationNotFoundException::new);
+		Reservation reservation;
+		try {
+			reservation = reservationRepository.findReservationByReservationNumber(request.getWaitingNumber())
+				.orElseThrow(ReservationNotFoundException::new);
 
-		reservation.markAsCancelled(LocalDateTime.now());
+			reservation.markAsCancelled(LocalDateTime.now());
 
-		// Redis 대기열 취소 이벤트 발행
-		waitingRedisRepository.removeWaiting(storeId, user.getId());
+			// Redis 대기열 취소 이벤트 발행
+			waitingRedisRepository.removeWaiting(storeId, user.getId());
+		} catch (RuntimeException e) {
+			// 롤백 처리
+			idempotencyService.rollbackIdempotencyKey(httpServletRequest.getHeader("Idempotency-Key"));
+			throw e;
+		}
 
 		CancelWaitingResponse response = CancelWaitingResponse.builder()
 			.waitingNumber(reservation.getReservationNumber())


### PR DESCRIPTION
## 작업 요약
- 웨이팅 삭제 시 ReservationNotFoundException 발생하는 경우 멱등키가 남아 웨이팅 취소가 불가능한 상황 발생 
- 멱등키 롤백 로직 추가 
## Issue Link
#365 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
* 대기 취소 작업 중 발생하는 오류에 대한 자동 롤백 기능 추가

**버그 수정**
* 대기 취소 프로세스의 오류 처리 강화로 불완전한 작업의 자동 복구 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->